### PR TITLE
Entrega 1 - Documentación Técnica Hernán Laura

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/autosave-editor.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/autosave-editor.txt
+.DS_Store

--- a/PRD.md
+++ b/PRD.md
@@ -1,0 +1,241 @@
+# PRD: AI Study Buddy
+
+**Author:** Hernán Laura
+**Status:** Draft v1
+**Date:** 2026-06-15
+**Context:** AI4Devs bootcamp final project (portfolio). Goal is a shippable, demo-able MVP — scope is deliberately tight.
+
+---
+
+## Problem Statement
+
+Anyone who needs to learn or be tested on the contents of a PDF — a student with a chapter assigned by their school or university, a professional working through a manual or report, someone preparing for an exam or certification — faces the same gap: reading the document passively rarely makes the material stick, and there is no fast way to both **learn it** and **check whether you've actually understood it**. Building study material by hand (slides, quizzes, flashcards) is tedious, so most people just re-read and hope. This app removes that work: it turns any PDF into an AI-generated lesson of alternating **instructional** and **activity** slides, so anyone can study the material and assess their understanding in a single flow, whatever their reason for learning it.
+
+---
+
+## Goals
+
+1. **Turn a PDF into a usable lesson with one upload.** A learner uploads a PDF and receives a generated deck of instructional + activity slides without any manual authoring.
+2. **Produce content that demonstrably teaches.** The core success bet is *learning gains* — measured by improvement between activity attempts (retakes) within a lesson.
+3. **Work everywhere from one codebase.** Ship to web first, with iOS/Android buildable from the same React Native + Expo project.
+4. **Keep AI cost off the builder.** Users supply their own AI API key, so the app can run with near-zero variable cost during the portfolio phase.
+5. **Be a clean portfolio artifact.** A reviewable repo with a real architecture (auth, backend, CI/CD) that a hiring manager or instructor can run and evaluate.
+
+---
+
+## Non-Goals
+
+1. **Authoring/editing slides by hand.** v1 generates slides; it does not ship a slide editor. *(Editing is high-effort UI and not needed to prove the core loop.)*
+2. **Multi-format ingest (DOCX, PPTX, URLs, video).** PDF only for v1. More formats on v2. *(Each format is its own parsing problem; PDF covers the stated use case.)*
+3. **Spaced-repetition / long-term scheduling across lessons.** No cross-lesson review queue yet. *(Valuable but a separate initiative; v1 proves single-lesson learning gains first.)*
+4. **Collaboration, sharing, or classroom/teacher features.** Single-user study experience only. *(The app is an individual study tool; multi-user roles and permissions add complexity for little MVP value.)*
+5. **Hosting/managing AI keys or billing.** No platform-managed inference or paid tiers in v1. *(Bring-your-own-key keeps cost and compliance simple for a portfolio MVP.)*
+6. **Native mobile store releases.** Mobile is buildable but the CI pipeline deploys **web only** at start. *(Store submission is process overhead, not core value.)*
+7. **Drag-drop interactions.** Matching activities are in scope (see R3), but implemented as tap-to-select-two-items-to-pair, not drag-and-drop. *(Drag-drop is meaningfully more work on RN + web for little added proof of the learning loop; revisit later.)*
+
+---
+
+## Target Users
+
+Anyone who needs to learn or assess themselves on the contents of a PDF, regardless of why they're learning it — students studying and self-testing on material assigned by a school or university, professionals upskilling from manuals or papers, and people preparing for exams or certifications. For v1 they are comfortable getting an AI API key (or willing to follow a short setup guide).
+
+---
+
+## User Stories
+
+Grouped by the core loop. Ordered by priority within each group.
+
+### Onboarding & setup
+- As a new user, I want to sign up, log in, and log out securely so that my documents and lessons stay private to me and are available whenever I return.
+- As a returning user, I want my session to persist across app restarts (until I log out) so that I don't have to re-authenticate every time.
+- As a user, I want to add my own AI API key once and have it securely stored so that I don't re-enter it every session.
+- As a user, I want clear guidance on where to get an API key so that setup doesn't block me.
+
+### Generating a lesson
+- As a learner, I want to upload a PDF and have the app generate a lesson so that I can start studying without manual prep.
+- As a learner, I want to choose whether the lesson is instructional-only, activity-only, or both, so that I get the format that fits how I want to study (e.g. just learn, just test myself, or both).
+- As a learner, I want to see generation progress (and a clear error if the PDF can't be parsed) so that I'm not staring at a blank screen.
+
+### Studying & activities
+- As a learner, I want to move through slides one at a time so that I can focus on a single concept or question.
+- As a learner, I want to answer activity slides (multiple choice, fill-in-the-blank, flashcards, open-ended, matching) and get immediate feedback so that I know whether I understood.
+- As a learner, I want to see my score at the end of the lesson so that I can gauge how much I learned.
+
+### Returning
+- As a learner, I want my generated lessons saved so that I can resume or retake them later.
+- As a learner, I want to leave a lesson partway through and return to the exact slide I left off so that I don't lose my place or have to start over.
+- As a learner, I want to retake a lesson's activities so that I can measure improvement (learning gains).
+
+---
+
+## Requirements
+
+### Must-Have (P0) — the MVP cannot ship without these
+
+**R1 — PDF upload & backend content extraction (text + images)** *(highest technical risk — build first)*
+Description: User uploads a PDF; **content extraction runs on the backend (Supabase Edge Function / storage-triggered function), not on the client.** The server extracts both the readable text and the embedded images, stores the images (Supabase Storage), and returns the text plus references to the extracted images. This is the riskiest piece and should be the first task delivered.
+Acceptance criteria:
+- Given a PDF, when the user uploads it, then the backend processes the whole document — every page — and extracts both its selectable text and its embedded images, returning success to the client.
+- Given a PDF that contains embedded images (diagrams, figures, charts, photos), when extraction runs, then those images are extracted, downscaled/recompressed (reduced dimensions + quality to limit storage cost and clutter), persisted to storage, and associated with the page/position they came from so generation can reference them.
+- Given a PDF with mixed pages (some text-only, some text+image, some image-only figures), when extraction runs, then text and images are captured from across all pages and kept in document order.
+- Extraction logic lives server-side so it behaves identically regardless of platform (web, iOS, Android) — the client never parses the PDF.
+- Given an unsupported or image-only/scanned PDF (text rendered as a scanned image), when extraction runs, then the user sees a clear error explaining the file can't be used (OCR of scanned text is out of scope for v1 — note this differs from extracting embedded figures, which is supported).
+- Given a file over the size limit, then the upload is rejected with a clear message.
+
+**R2 — AI lesson generation (instructional + activity slides)**
+Description: The extracted text **and the extracted images (R1)** are sent to the AI **through a Supabase Edge Function that injects the user's stored key server-side** (the key and the provider call never live in the client). The function uses the **Vercel AI SDK** so providers/models are swappable without reworking generation. It returns a structured deck of typed slides, honoring the lesson composition chosen in R2.1, and may attach relevant extracted images to slides.
+Acceptance criteria:
+- Given extracted text, when generation runs, then the result is an ordered list of slides each typed as `instructional` or `activity`.
+- The AI provider call is made from the Edge Function via the Vercel AI SDK, not the client; the key is read server-side and never exposed to the device or logs.
+- Image placement: where the extracted image carries a description/position (from R1), generation uses that metadata to choose the slide; where only the raw image is available, a vision-capable model decides placement. Either way the generated slide references the stored image (R1) so it renders alongside the content; slides without a relevant image render text-only.
+- Image references in the generated deck point to persisted images; a missing or broken image reference degrades gracefully to text-only rather than failing the slide.
+- Activity slides include: multiple choice, fill-in-the-blank, flashcard, open-ended, and matching types (see R3 for details).
+- Each activity slide carries the correct answer(s) and, where applicable, an explanation.
+- Generation shows progress state and surfaces a readable error on failure (bad key, rate limit, timeout) without crashing.
+
+**R2.1 — Lesson composition choice (instructional / activity / both)**
+Description: Before generating, the learner chooses what the lesson should contain: instructional slides only, activity slides only, or both.
+Acceptance criteria:
+- Before generation, the learner can pick one of: `instructional only`, `activity only`, `both`. Default is `both`.
+- Given `instructional only`, when generation runs, then the deck contains only instructional slides and no activity slides.
+- Given `activity only`, when generation runs, then the deck contains only activity slides and no instructional slides.
+- Given `both`, when generation runs, then the deck contains a mix of instructional and activity slides.
+- The chosen composition is passed to the Edge Function (R2) and reflected in the generated deck; the prompt enforces it.
+- Edge case: if `activity only` is chosen, the end-of-lesson score (R7) still works; if `instructional only` is chosen, there are no activities to score and the results summary reflects that (no score shown).
+
+**R3 — Activity slide types with feedback**
+Description: Render and grade the supported activity types.
+Acceptance criteria (per type):
+- Multiple choice: learner selects an option; correct/incorrect feedback shown immediately.
+- Fill-in-the-blank: learner types an answer; graded against accepted answer(s) (case-insensitive, trimmed).
+- Flashcard / recall: learner reveals the answer and self-marks recalled / not recalled.
+- Open-ended / short answer: learner submits free text; shown a model answer for self-assessment (not auto-graded in v1).
+- Matching: learner pairs related items by tapping one item then its match (no drag-drop); correctness shown on submit.
+- *(P0 floor: multiple choice + fill-in-the-blank + flashcards. Open-ended / short answer and matching are also in scope for v1. Drag-drop interaction is **out of scope** — matching uses tap-to-select-two — see Non-Goals.)*
+
+**R4 — Slide navigation & lesson player**
+Description: A player to move through the deck one slide at a time.
+Acceptance criteria:
+- Given a generated lesson, the learner can advance and go back through slides.
+- A slide that has an associated extracted image (R2) renders that image alongside its content; image-less slides render text-only.
+- Progress through the deck is visible.
+- The player works on web and on a mobile viewport (responsive), and images scale appropriately to the viewport.
+
+**R5 — Auth & persistence**
+Description: Supabase-backed accounts; lessons saved per user.
+Acceptance criteria:
+- User can sign up, log in, and log out.
+- A generated lesson is persisted to the user's account and reappears after logout/login.
+- A logged-out user cannot access another user's lessons (row-level security).
+
+**R6 — Bring-your-own AI key (server-side proxy)**
+Description: User stores their own API key; **all AI calls are proxied through a Supabase Edge Function** so the key is used server-side and never reaches the client at call time.
+Acceptance criteria:
+- User can save, update, and remove their key.
+- The key is stored encrypted/secured server-side, scoped to the user, never returned to the client after save, and never written to logs.
+- Generation reads the key inside the Edge Function (R2); the client only triggers the function and never holds the raw key during a request.
+- Generation fails gracefully with guidance if no key is set.
+
+**R7 — Score / results summary**
+Description: End-of-lesson summary showing performance.
+Acceptance criteria:
+- After completing activity slides, the learner sees a score (correct / total on auto-gradable types).
+- Retaking the lesson records a new score so improvement is visible.
+- For an instructional-only lesson (R2.1), the summary shows a completion state instead of a score, since there are no activities to grade.
+
+**R8 — Cross-platform build & web CI/CD**
+Description: One Expo codebase; GitHub Actions builds and deploys web.
+Acceptance criteria:
+- The app runs via Expo on web, iOS, and Android (web is the deployed target).
+- On merge to main, GitHub Actions builds the web app and deploys it.
+- A failing build blocks deploy.
+
+**R9 — Resume mid-lesson**
+Description: The learner's position in a lesson is saved so they can leave and return to the exact slide they left off.
+Acceptance criteria:
+- As the learner advances through slides, their current position is persisted to their account (not just local state).
+- Given an in-progress lesson, when the learner reopens it (including after logout/login or on another device), then they resume at the exact slide they left off.
+- Already-answered activity slides retain their state on resume so progress and score (R7) stay consistent.
+- A completed lesson can be restarted from the beginning (and retaken per R7).
+
+### Nice-to-Have (P1) — fast follows, core works without them
+
+- **Regenerate / adjust** a lesson (e.g., "make it harder," "more activities," fewer slides).
+- **Per-slide difficulty or topic tagging** surfaced to the learner.
+- **Page-range selection** so a learner can generate from part of a long PDF.
+- **Open-ended auto-grading** via AI (instead of self-assessment).
+
+### Future Considerations (P2) — out of scope, but design shouldn't block them
+
+- Spaced-repetition review queue across lessons (data model should allow per-activity attempt history).
+- Additional ingest formats (DOCX, URLs) — keep extraction decoupled from generation.
+- **Paid tier with managed AI (no bring-your-own-key).** A paid plan where the app's own AI service powers generation, so paying users don't supply or manage an API key — the platform covers inference as part of the subscription. Free tier keeps the bring-your-own-key model (R6); the Edge Function proxy (R2/R6) should keep the key source swappable so it can read either the user's key (free) or the platform key (paid) without reworking generation. Implies usage limits/metering and billing.
+- Native app store releases via the same CI pipeline.
+- Drag-drop interaction for matching (v1 uses tap-to-select-two).
+- Sharing or exporting a generated deck (e.g., to PPTX/PDF).
+
+---
+
+## Success Metrics
+
+The headline bet is **learning gains**, with supporting funnel and quality metrics.
+
+### Leading indicators (days → weeks)
+- **Generation success rate:** % of uploads that produce a usable lesson. Target: ≥ 90% of supported (non-scanned) PDFs. *Measure: generation events succeeded / attempted.*
+- **Lesson completion rate:** % of started lessons where the learner reaches the results summary. Target: ≥ 60%.
+- **Activity engagement:** median % of activity slides attempted per started lesson. Target: ≥ 70%.
+- **Generation time:** median time from upload to first slide. Target: under ~30s for a typical chapter-length PDF (model-dependent).
+
+### Lagging indicators (weeks → months)
+- **Learning gain (primary):** improvement in score on lesson retake. Success threshold: average +15 percentage points on retake; stretch: +25. *Measure: per-user delta between first and best/second attempt on auto-gradable activities.*
+- **Repeat usage:** % of users who generate a second lesson within 14 days. Target: ≥ 30%.
+
+### Measurement notes
+- Instrument generation, slide views, activity attempts (with correctness), and completion as events tied to user + lesson.
+- Evaluate the primary metric on a small cohort (even classmates/testers) at ~2 and ~4 weeks post-launch.
+
+---
+
+## Resolved Decisions
+
+- **AI key handling:** proxied through a **Supabase Edge Function**. The key is stored server-side and the provider call is made from the function — the client never holds the key at call time. (Drives R2, R6.)
+- **AI integration layer:** use the **Vercel AI SDK** (ai-sdk.dev) so the app is provider-agnostic and can switch between providers/models without reworking the generation code. (Drives R2.)
+- **PDF content extraction:** runs on the **backend** (Edge Function), not the client. It is the **highest technical risk and the first task to build**. (Drives R1.)
+- **Image storage:** extracted images are **downscaled and recompressed** (reduced dimensions + quality) before storage to limit storage cost and on-slide clutter. (Drives R1.)
+- **Image placement:** when the extracted image carries a description/position, generation uses that metadata to pick the slide; when only the raw image is available, a vision-capable model decides placement. (Drives R2.)
+- **Learning-gain measurement:** measured via **retake improvement only**. No pre/post quiz in this project. (Drives Success Metrics.)
+- **Matching:** **in scope** for v1, implemented as tap-to-select-two-items-to-pair (no drag-drop). Open-ended / short answer also stays in. (Drives R3, Non-Goals.)
+
+## Open Questions
+
+- **[Eng — research spike]** Which server-side PDF extraction approach works in the Edge Function runtime (Deno) and can extract both text and embedded images with page/position info? Candidate to evaluate first: [liteparse](https://github.com/run-llama/liteparse); compare against other PDF parsers. The spike should also confirm whether it can detect scanned/image-only PDFs to trigger R1's error path. *Blocking for R1.*
+- **[Product]** Max PDF size / page count for v1, given generation cost and latency — to be determined by the team through testing. *Non-blocking; set a sensible cap after the R1 spike.*
+
+---
+
+## Timeline Considerations
+
+This is a bootcamp final project, so phase to guarantee a working demo of the **core loop** (upload → generate → study → score) before polishing.
+
+**Phase 0 — Foundations & de-risking (do first):** Two first deliverables — (a) authentication with Supabase Auth (sign up / log in / log out; the first work ticket and the `auth.uid()` foundation that RLS later builds on), and (b) a research spike on PDF extraction (evaluate liteparse and alternatives for text + images + position info + scanned-PDF detection) followed by the backend extraction Edge Function (R1), proven on real PDFs. Extraction is the highest technical risk.
+
+**Phase 1 — Core loop (must demo):** R2 generation (via Edge Function proxy), R2.1 composition choice, R3 (MCQ + fill-in-blank + flashcards + open-ended + matching), R4 player, R7 score.
+
+**Phase 2 — Persistence & platform:** R5 lesson persistence + RLS (auth itself lands in Phase 0), R6 server-side bring-your-own key, R9 resume mid-lesson (depends on persistence), R8 web CI/CD on GitHub Actions.
+
+**Phase 3 — Polish:** P1 items as time allows, mobile responsiveness pass.
+
+**Dependencies & sequencing:**
+- Authentication (R5 auth) and backend PDF extraction (R1) are the first deliverables — auth is the foundation for per-user data and RLS; extraction is the highest technical risk and everything downstream depends on it.
+- The Edge Function proxy pattern is shared by R1, R2, and R6 — build the function scaffolding once, early.
+- CI/CD (R8) deploys web only at start; native builds are validated locally but not released.
+
+---
+
+## Appendix: Constraints (as specified)
+
+- **Stack:** React Native + Expo, targeting Android, iOS, and web via react-native-web.
+- **Auth + backend:** Supabase.
+- **CI/CD:** GitHub Actions — initially build + deploy **web** only.
+- **AI usage:** user supplies their own API key (free tier); calls go through the **Vercel AI SDK** for provider-agnostic generation.
+- **PDF extraction:** server-side, candidate library [liteparse](https://github.com/run-llama/liteparse) pending the R1 research spike.

--- a/prompts.md
+++ b/prompts.md
@@ -1,6 +1,7 @@
 > Detalla en esta sección los prompts principales utilizados durante la creación del proyecto, que justifiquen el uso de asistentes de código en todas las fases del ciclo de vida del desarrollo. Esperamos un máximo de 3 por sección, principalmente los de creación inicial o  los de corrección o adición de funcionalidades que consideres más relevantes.
 Puedes añadir adicionalmente la conversación completa como link o archivo adjunto si así lo consideras
 
+> Note: prompts are reproduced verbatim (exactly as written). The product had many feature-addition prompts, so a few sections list more than the suggested 3 to preserve every substantive prompt. Iteration/review prompts that don't map to a single deliverable section are collected at the end.
 
 ## Índice
 
@@ -16,11 +17,21 @@ Puedes añadir adicionalmente la conversación completa como link o archivo adju
 
 ## 1. Descripción general del producto
 
-**Prompt 1:**
+**Prompt 1:** _(initial idea — invoked via the `/write-spec` skill)_
 
-**Prompt 2:**
+> I want to build an app that will parse a pdf and will create slides to teach the content of the pdf to the user. Each slide could be instructional or an activity
 
-**Prompt 3:**
+**Prompt 2:** _(broaden the problem to students who want to self-assess)_
+
+> Lets modify the problem statement so it also includes students that wants to assess if they have learned what they are studying, so they could receive a pdf from their school, university, etc.; they will study it, and they want to assess themselves. Modify both the PRD and the readme
+
+**Prompt 3:** _(rewrite the objective so it isn't framed around self-learners)_
+
+> I don´t like this statement: "Self-learners constantly accumulate PDFs they want to actually learn", the objective still looks like being for self-learners, and that's not what I want, this should be for anyone needing to learn or assess themselves. please  completely re-write the objective
+
+**Prompt 4:** _(add a paid tier — Future Considerations / P2)_
+
+> On P2, add a paid-tier that will not require bring-your-own-key AI key, it will use an AI service as part of the paid features
 
 ---
 
@@ -28,98 +39,137 @@ Puedes añadir adicionalmente la conversación completa como link o archivo adju
 
 ### **2.1. Diagrama de arquitectura:**
 
-**Prompt 1:**
+**Prompt 1:** _(stack and high-level architecture, submitted via the intake form — the constraints were written verbatim)_
 
-**Prompt 2:**
-
-**Prompt 3:**
+> PDF-to-slides app details — Audience: Self-learners / general public · Context: Bootcamp / course final project (portfolio) · Activity types: "Multiple choice questions, Fill in the blank, Flashcards / recall, Open-ended / short answer, Matching / drag-drop" · Success signals: Learning gains (quiz scores) · Constraints:
+>
+> I'll use react-native with expo for android, ios and web using react-native-web. The authentication and backend should use supabase, github actions for the pipeline (but at start it will only build and deploy web) and the user should add their own api key for the ai usage
 
 ### **2.2. Descripción de componentes principales:**
 
-**Prompt 1:**
+**Prompt 1:** _(AI key handling, server-side extraction, and scope of matching)_
 
-**Prompt 2:**
+> * Where the AI key lives: proxied through a Supabase Edge Function
+> * PDF extraction: this is the highest technical risk, it should be done on the BE and it should be one of the first tasks to achieve.
+> * Open-ended + matching/drag-drop: leave drag-drop out of the current scope
 
-**Prompt 3:**
+**Prompt 2:** _(extract and use images from the PDF)_
+
+> the pdf can also contain images, not only text, modify the PRD so it reflects that images should also be extracted from the pdf and used in the slides
+
+**Prompt 3:** _(answers to the open questions — AI provider, extraction library, image placement, image/PDF caps, learning-gain measurement, scanned-PDF detection)_
+
+> Here are responses to the Open Questions:
+>
+> [Eng] Which AI provider/model is assumed for the bring-your-own key (OpenAI, Anthropic, multiple)? Determines the generation prompt/response contract. Blocking for R2.
+> use vercel https://ai-sdk.dev/ so different providers can be used easily
+> [Eng] Which server-side PDF extraction library runs in the Edge Function runtime (Deno), and can it extract both text and embedded images (with page/position info)? What's the fallback if it can't handle a given PDF? Blocking for R1.
+> this point needs research to be made, a possible solution is https://github.com/run-llama/liteparse or some other pdf-parser library
+> [Eng/product] How does generation decide which extracted image belongs on which slide — does the AI receive image descriptions/positions, the images themselves (vision model), or a simple page-proximity heuristic? Affects the R2 contract and provider choice. Blocking for R2 image placement.
+> if the image has description or position, it can be used to decide which slide to put it on, but if it is just a vision model, it will need to be decided by the AI.
+> [Product] Cap on number/size of images stored per PDF, given storage cost and slide clutter? Non-blocking; set a sensible cap.
+> images should be reduced in size and quality to reduce storage cost and clutter.
+> [Data] Without a pre-quiz in v1, is "retake improvement" a credible proxy for learning gain, or should the P1 pre/post quiz be pulled into v1? Non-blocking, revisit after first tests.
+> remove any reference to pre-quiz as it is not in the scope of the project.
+> [Product] Max PDF size / page count for v1, given generation cost and latency? Non-blocking; set a sensible cap.
+> this will need to be tested and decided by the team.
+> [Eng] How are scanned/image PDFs detected so R1's error path triggers reliably? Non-blocking.
+> test what https://github.com/run-llama/liteparse can do and if it can detect scanned/image PDFs.
 
 ### **2.3. Descripción de alto nivel del proyecto y estructura de ficheros**
 
-**Prompt 1:**
-
-**Prompt 2:**
-
-**Prompt 3:**
+_No specific prompt in this session — generated as part of the README fill (see prompt under section 4)._
 
 ### **2.4. Infraestructura y despliegue**
 
-**Prompt 1:**
+**Prompt 1:** _(CI/CD and deployment defined in the constraints prompt under 2.1)_
 
-**Prompt 2:**
-
-**Prompt 3:**
+> ...github actions for the pipeline (but at start it will only build and deploy web)...
 
 ### **2.5. Seguridad**
 
-**Prompt 1:**
+**Prompt 1:** _(server-side AI key handling — part of the prompt under 2.2)_
 
-**Prompt 2:**
-
-**Prompt 3:**
+> * Where the AI key lives: proxied through a Supabase Edge Function
 
 ### **2.6. Tests**
 
-**Prompt 1:**
-
-**Prompt 2:**
-
-**Prompt 3:**
+_No specific prompt in this session._
 
 ---
 
 ### 3. Modelo de Datos
 
-**Prompt 1:**
+**Prompt 1:** _(store slides as JSON instead of tables; images as URLs)_
 
-**Prompt 2:**
+> The slides should be a json containing all the needed data instead of tables (the images should be a url)
 
-**Prompt 3:**
+**Prompt 2:** _(promote resume mid-lesson into v1 — drove `current_slide_index` in `lesson_attempts`)_
+
+> Make the following part of v1, not nice-to-have
+>
+> * Resume mid-lesson at the exact slide left off.
 
 ---
 
 ### 4. Especificación de la API
 
-**Prompt 1:**
+**Prompt 1:** _(lesson composition choice — added the `composition` parameter to generation)_
 
-**Prompt 2:**
+> change the prd so the user can select if he wants only instructional slides, only activity slides, or both
 
-**Prompt 3:**
+**Prompt 2:** _(generate the README, which produced the API spec along with sections 3, 5, 6 and 7)_
+
+> please fill in the readmd.md, do it in english
 
 ---
 
 ### 5. Historias de Usuario
 
-**Prompt 1:**
+**Prompt 1:** _(add an authentication user story)_
 
-**Prompt 2:**
+> add a user story for authentication
 
-**Prompt 3:**
+**Prompt 2:** _(prioritize it as the first story)_
+
+> make it the first story to be done
 
 ---
 
 ### 6. Tickets de Trabajo
 
-**Prompt 1:**
+**Prompt 1:** _(make authentication the first ticket)_
 
-**Prompt 2:**
-
-**Prompt 3:**
+> also make authentication as the first ticket
 
 ---
 
 ### 7. Pull Requests
 
-**Prompt 1:**
+_No specific prompt in this session — the planned Pull Requests were generated as part of the README fill (see prompt under section 4)._
 
-**Prompt 2:**
+---
 
-**Prompt 3:**
+## Prompts adicionales de iteración y revisión
+
+These prompts drove refinement, reconciliation and review across the documents rather than a single deliverable section:
+
+**Refine R1 to cover the whole PDF (not just text-based):**
+
+> R1 still talks about a text-based pdf, check on the entire pdf
+
+**After manual edits to the file:**
+
+> I've edited the .md file, re-read it
+
+**Reconcile the matching/drag-drop inconsistency across sections:**
+
+> yes, reconcile it
+
+**Final cross-document review:**
+
+> Do a final review of both PRD.md and readme.md, check that both files are correct by themselves, and also that their are consistent between them
+
+**Generate this prompts log:**
+
+> ok, now fill the file prompts.md using the current session, be extremely precise saving the exact promps I've wrote

--- a/readme.md
+++ b/readme.md
@@ -11,71 +11,185 @@
 
 ---
 
+> Note: section titles are kept in Spanish to match the required deliverable template; all content is written in English as requested.
+
 ## 0. Ficha del proyecto
 
 ### **0.1. Tu nombre completo:**
 
+Hernán Laura
+
 ### **0.2. Nombre del proyecto:**
+
+AI Study Buddy
 
 ### **0.3. Descripción breve del proyecto:**
 
+AI Study Buddy turns any PDF into an AI-generated lesson made of alternating instructional and activity slides, so a learner can both study the material and test themselves in one flow. The user uploads a PDF; the backend extracts its text and embedded images; an AI model generates a structured deck (instructional slides, plus activities such as multiple choice, fill-in-the-blank, flashcards, open-ended, and matching). The app runs on web, iOS, and Android from a single React Native + Expo codebase.
+
 ### **0.4. URL del proyecto:**
 
-> Puede ser pública o privada, en cuyo caso deberás compartir los accesos de manera segura. Puedes enviarlos a [alvaro@lidr.co](mailto:alvaro@lidr.co) usando algún servicio como [onetimesecret](https://onetimesecret.com/).
+_Pending deployment (web target via GitHub Actions)._
 
 ### 0.5. URL o archivo comprimido del repositorio
 
-> Puedes tenerlo alojado en público o en privado, en cuyo caso deberás compartir los accesos de manera segura. Puedes enviarlos a [alvaro@lidr.co](mailto:alvaro@lidr.co) usando algún servicio como [onetimesecret](https://onetimesecret.com/). También puedes compartir por correo un archivo zip con el contenido
-
+_https://github.com/&lt;org-or-user&gt;/AI4Devs-finalproject (to be completed)._
 
 ---
 
 ## 1. Descripción general del producto
 
-> Describe en detalle los siguientes aspectos del producto:
-
 ### **1.1. Objetivo:**
 
-> Propósito del producto. Qué valor aporta, qué soluciona, y para quién.
+Anyone who needs to learn or be tested on the contents of a PDF — a student with a chapter assigned by their school or university, a professional working through a manual or report, someone preparing for an exam or certification — faces the same gap: reading the document passively rarely makes the material stick, and there is no fast way to both learn it and check whether you've actually understood it. Building study material by hand (slides, quizzes, flashcards) is tedious, so most people just re-read and hope. AI Study Buddy closes the gap between "I have this PDF" and "teach me this and check that I learned it."
+
+The product serves anyone who needs to learn or assess themselves on a document, whatever the reason — students studying and self-testing on assigned material, professionals upskilling from manuals or papers, and people preparing for exams or certifications. The value is speed and learning effectiveness — one upload produces a ready-to-study lesson, and the core success bet is **learning gains**, measured by score improvement when a learner retakes a lesson's activities.
 
 ### **1.2. Características y funcionalidades principales:**
 
-> Enumera y describe las características y funcionalidades específicas que tiene el producto para satisfacer las necesidades identificadas.
+- **One-upload lesson generation.** Upload a PDF and receive a generated deck of instructional + activity slides with no manual authoring.
+- **Lesson composition choice.** Before generating, the learner chooses instructional-only, activity-only, or both (default both).
+- **Full-document extraction (text + images).** The backend processes every page, extracting selectable text and embedded images (figures, diagrams, charts). Relevant images are attached to the slides they illustrate.
+- **Five activity types with immediate feedback.** Multiple choice, fill-in-the-blank, flashcards, open-ended/short answer, and matching (tap-to-select-two-items-to-pair; no drag-drop in v1).
+- **Lesson player.** Move through slides one at a time on web and mobile; images scale to the viewport.
+- **Resume mid-lesson.** The learner's position is persisted server-side and resumes at the exact slide across logout/login and devices.
+- **Score & results summary.** End-of-lesson score on auto-gradable activities; retakes record new scores so improvement is visible. Instructional-only lessons show a completion state instead of a score.
+- **Bring-your-own AI key.** Users supply their own AI API key; all AI calls are proxied server-side so the key never reaches the client at call time.
+- **Cross-platform.** A single Expo codebase targets web (deployed), iOS, and Android.
 
 ### **1.3. Diseño y experiencia de usuario:**
 
-> Proporciona imágenes y/o videotutorial mostrando la experiencia del usuario desde que aterriza en la aplicación, pasando por todas las funcionalidades principales.
+The core user flow is: **sign up / log in → add AI API key → upload a PDF → choose lesson composition → watch generation progress → study the deck slide-by-slide (answering activities with immediate feedback) → see results / learning gain → resume or retake later.**
+
+_Screenshots and a video walkthrough will be added once the UI is implemented._
 
 ### **1.4. Instrucciones de instalación:**
-> Documenta de manera precisa las instrucciones para instalar y poner en marcha el proyecto en local (librerías, backend, frontend, servidor, base de datos, migraciones y semillas de datos, etc.)
+
+Prerequisites: Node.js LTS, npm or pnpm, the Expo CLI, the Supabase CLI, and Docker (for the local Supabase stack).
+
+```bash
+# 1. Clone and install
+git clone <repo-url>
+cd AI4Devs-finalproject
+npm install
+
+# 2. Start the local Supabase stack (Postgres, Auth, Storage, Edge Functions)
+supabase start
+
+# 3. Apply database migrations and seeds
+supabase db reset   # runs migrations + seed.sql
+
+# 4. Configure environment variables
+cp .env.example .env
+#   EXPO_PUBLIC_SUPABASE_URL=...
+#   EXPO_PUBLIC_SUPABASE_ANON_KEY=...
+#   (the user's AI API key is added in-app and stored server-side, not in .env)
+
+# 5. Serve the Edge Functions locally (extraction + generation)
+supabase functions serve
+
+# 6. Run the app
+npx expo start          # choose web / iOS / Android
+```
 
 ---
 
 ## 2. Arquitectura del Sistema
 
 ### **2.1. Diagrama de arquitectura:**
-> Usa el formato que consideres más adecuado para representar los componentes principales de la aplicación y las tecnologías utilizadas. Explica si sigue algún patrón predefinido, justifica por qué se ha elegido esta arquitectura, y destaca los beneficios principales que aportan al proyecto y justifican su uso, así como sacrificios o déficits que implica.
 
+```mermaid
+flowchart TD
+    subgraph Client["Client — React Native + Expo"]
+        UI[Lesson UI & Player]
+    end
+
+    subgraph Supabase["Supabase (Backend-as-a-Service)"]
+        Auth[Auth]
+        DB[(Postgres + RLS)]
+        Storage[(Storage: PDFs & images)]
+        EF1[Edge Function: extract]
+        EF2[Edge Function: generate-lesson]
+    end
+
+    AI[AI provider via Vercel AI SDK]
+
+    UI -->|sign in| Auth
+    UI -->|upload PDF| Storage
+    Storage --> EF1
+    EF1 -->|text + downscaled images| Storage
+    EF1 -->|extracted content| DB
+    UI -->|generate lesson| EF2
+    EF2 -->|reads user key server-side| DB
+    EF2 -->|prompt: text + images| AI
+    AI -->|structured deck| EF2
+    EF2 -->|lesson + slides| DB
+    UI -->|read deck, save progress| DB
+```
+
+The architecture follows a **client + Backend-as-a-Service (BaaS)** pattern built on Supabase, with security-sensitive and platform-dependent logic pushed into **Edge Functions** rather than the client.
+
+This was chosen because it is a portfolio MVP that must be shippable quickly while still demonstrating real architecture: Supabase provides Auth, Postgres (with row-level security), Storage, and serverless functions out of the box, removing the need to build and host a custom backend. Pushing PDF extraction and AI calls into Edge Functions keeps two concerns server-side: the AI key never reaches the client, and parsing behaves identically across web/iOS/Android.
+
+Benefits: fast to build, low operational overhead, secure key handling, one codebase for three platforms. Trade-offs: dependence on Supabase's Deno runtime (constrains library choices for PDF parsing — the main technical risk), Edge Function execution limits for large PDFs, and BaaS lock-in.
 
 ### **2.2. Descripción de componentes principales:**
 
-> Describe los componentes más importantes, incluyendo la tecnología utilizada
+- **Mobile/web client — React Native + Expo (TypeScript).** UI, lesson player, slide rendering and activity interactions. Runs on web via react-native-web and natively on iOS/Android.
+- **Supabase Auth.** Email/password accounts and session management.
+- **Supabase Postgres.** Stores documents, extracted-image metadata, lessons (with the slide deck held in a `slides` JSON column), lesson attempts (with responses in an `answers` JSON column), and the user's secured AI key. Row-level security isolates each user's data.
+- **Supabase Storage.** Stores uploaded PDFs and the extracted (downscaled/recompressed) images.
+- **Edge Function `extract`.** Server-side PDF content extraction (text + images with page/position). Highest technical risk; candidate library [liteparse](https://github.com/run-llama/liteparse) pending a research spike.
+- **Edge Function `generate-lesson`.** Reads the user's key server-side and calls the AI through the **Vercel AI SDK** (provider-agnostic), returning a structured, typed deck.
+- **CI/CD — GitHub Actions.** Builds and deploys the web target on merge to main (native builds validated locally, not released in v1).
 
 ### **2.3. Descripción de alto nivel del proyecto y estructura de ficheros**
 
-> Representa la estructura del proyecto y explica brevemente el propósito de las carpetas principales, así como si obedece a algún patrón o arquitectura específica.
+```
+AI4Devs-finalproject/
+├─ app/                  # Expo Router screens (auth, upload, lesson player, results)
+├─ src/
+│  ├─ components/        # UI components (slide renderers, activity widgets, player controls)
+│  ├─ features/          # lesson, document, auth feature modules
+│  ├─ lib/               # Supabase client, API hooks, types
+│  └─ utils/
+├─ supabase/
+│  ├─ functions/
+│  │  ├─ extract/        # PDF text + image extraction Edge Function
+│  │  └─ generate-lesson/# AI generation Edge Function (Vercel AI SDK)
+│  ├─ migrations/        # SQL schema + RLS policies
+│  └─ seed.sql
+├─ .github/workflows/    # GitHub Actions: build + deploy web
+├─ PRD.md                # product requirements document
+└─ readme.md
+```
+
+The structure separates the cross-platform client (`app/`, `src/`) from the backend (`supabase/`), keeping extraction decoupled from generation so future ingest formats can be added without touching generation.
 
 ### **2.4. Infraestructura y despliegue**
 
-> Detalla la infraestructura del proyecto, incluyendo un diagrama en el formato que creas conveniente, y explica el proceso de despliegue que se sigue
+The web app is built and deployed by **GitHub Actions** on merge to `main`. Supabase hosts the database, auth, storage, and Edge Functions; migrations are applied via the Supabase CLI. Native (iOS/Android) builds are produced via Expo and validated locally but are not published to stores in v1.
+
+```mermaid
+flowchart LR
+    Dev[Developer] -->|push / merge to main| GH[GitHub]
+    GH --> GA[GitHub Actions]
+    GA -->|build web| Web[Web hosting]
+    GA -->|deploy functions / migrations| SB[Supabase]
+    GA -.->|fail build blocks deploy| GA
+```
 
 ### **2.5. Seguridad**
 
-> Enumera y describe las prácticas de seguridad principales que se han implementado en el proyecto, añadiendo ejemplos si procede
+- **AI key never on the client at call time.** Keys are stored server-side, scoped to the user, never returned after save, and never logged; all AI calls run inside the `generate-lesson` Edge Function.
+- **Row-level security (RLS).** Postgres policies ensure a user can only read/write their own documents, lessons, and attempts.
+- **Server-side extraction.** The client never parses PDFs, avoiding untrusted parsing on the device and keeping behavior consistent.
+- **Auth-gated access.** All data operations require an authenticated Supabase session.
+- **Input limits.** PDF size/page caps and rejection of unsupported/scanned files reduce abuse and cost exposure.
 
 ### **2.6. Tests**
 
-> Describe brevemente algunos de los tests realizados
+Planned coverage: unit tests for activity grading (e.g. case-insensitive fill-in-the-blank, matching correctness), Edge Function tests for the extraction and generation contracts (typed deck shape, composition honored, graceful image fallback), and end-to-end tests of the core loop (upload → generate → study → score → resume). A research-spike test set of varied real PDFs (text-only, text+image, scanned) validates R1 extraction and scanned-PDF detection.
 
 ---
 
@@ -83,52 +197,255 @@
 
 ### **3.1. Diagrama del modelo de datos:**
 
-> Recomendamos usar mermaid para el modelo de datos, y utilizar todos los parámetros que permite la sintaxis para dar el máximo detalle, por ejemplo las claves primarias y foráneas.
+```mermaid
+erDiagram
+    USERS ||--o{ USER_AI_KEYS : has
+    USERS ||--o{ DOCUMENTS : uploads
+    USERS ||--o{ LESSONS : owns
+    USERS ||--o{ LESSON_ATTEMPTS : makes
+    DOCUMENTS ||--o{ EXTRACTED_IMAGES : contains
+    DOCUMENTS ||--o{ LESSONS : generates
+    LESSONS ||--o{ LESSON_ATTEMPTS : tracked_by
 
+    USERS {
+        uuid id PK
+        text email
+        timestamptz created_at
+    }
+    USER_AI_KEYS {
+        uuid id PK
+        uuid user_id FK
+        text provider
+        text encrypted_key
+        timestamptz created_at
+    }
+    DOCUMENTS {
+        uuid id PK
+        uuid user_id FK
+        text filename
+        text storage_path
+        int page_count
+        int size_bytes
+        text status
+        timestamptz created_at
+    }
+    EXTRACTED_IMAGES {
+        uuid id PK
+        uuid document_id FK
+        text storage_path
+        int page
+        jsonb position
+        int width
+        int height
+    }
+    LESSONS {
+        uuid id PK
+        uuid user_id FK
+        uuid document_id FK
+        text composition
+        text status
+        jsonb slides
+        timestamptz created_at
+    }
+    LESSON_ATTEMPTS {
+        uuid id PK
+        uuid lesson_id FK
+        uuid user_id FK
+        int current_slide_index
+        numeric score
+        jsonb answers
+        timestamptz started_at
+        timestamptz completed_at
+    }
+```
 
 ### **3.2. Descripción de entidades principales:**
 
-> Recuerda incluir el máximo detalle de cada entidad, como el nombre y tipo de cada atributo, descripción breve si procede, claves primarias y foráneas, relaciones y tipo de relación, restricciones (unique, not null…), etc.
+- **users** — backed by Supabase `auth.users`. `id` (PK, uuid). Owns documents, lessons, attempts, and AI keys.
+- **user_ai_keys** — the user's stored AI key. `encrypted_key` is secured server-side, `provider` indicates which provider/model (used via the Vercel AI SDK). FK `user_id` → users; unique per (user, provider). Never returned to the client.
+- **documents** — an uploaded PDF. `storage_path` points to Supabase Storage; `status` ∈ {uploaded, extracting, extracted, failed}; `page_count`/`size_bytes` enforce caps. FK `user_id` → users.
+- **extracted_images** — images pulled from a PDF (downscaled/recompressed) and uploaded to Storage; each row exposes a public `url` referenced from the slides JSON. `page` + `position` (jsonb) record where the image appeared so generation can place it. FK `document_id` → documents.
+- **lessons** — a generated deck. `composition` ∈ {instructional, activity, both}; `status` ∈ {generating, ready, failed}. **`slides` (jsonb)** holds the entire ordered deck as a single JSON document — each slide object carries `id`, `order_index`, `type` ∈ {instructional, activity}, `activity_type` ∈ {multiple_choice, fill_blank, flashcard, open_ended, matching} (null for instructional), `content`, an `image_url` (nullable, points to an extracted_images URL), and `correct_answer`/`explanation` for grading. No separate slides table. FK `user_id` → users, `document_id` → documents.
+- **lesson_attempts** — one run through a lesson. `current_slide_index` enables resume; `score` set on completion; **`answers` (jsonb)** records the learner's responses for the attempt, keyed by slide `id`, each with the submitted response and `is_correct`. FK `lesson_id` → lessons, `user_id` → users.
+
+All user-owned tables enforce row-level security (`user_id = auth.uid()`).
 
 ---
 
 ## 4. Especificación de la API
 
-> Si tu backend se comunica a través de API, describe los endpoints principales (máximo 3) en formato OpenAPI. Opcionalmente puedes añadir un ejemplo de petición y de respuesta para mayor claridad
+Three core endpoints (implemented as Supabase Edge Functions / PostgREST), shown in OpenAPI.
+
+```yaml
+openapi: 3.0.0
+info:
+  title: AI Study Buddy API
+  version: 0.1.0
+paths:
+  /functions/v1/extract:
+    post:
+      summary: Upload a PDF and extract its text + images (server-side)
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file: { type: string, format: binary }
+      responses:
+        "202":
+          description: Accepted; extraction started
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  document_id: { type: string, format: uuid }
+                  status: { type: string, example: extracting }
+        "400": { description: Unsupported/scanned PDF or file too large }
+
+  /functions/v1/generate-lesson:
+    post:
+      summary: Generate a typed slide deck from an extracted document
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [document_id, composition]
+              properties:
+                document_id: { type: string, format: uuid }
+                composition:
+                  type: string
+                  enum: [instructional, activity, both]
+      responses:
+        "201":
+          description: Lesson generated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  lesson_id: { type: string, format: uuid }
+                  slides:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: { type: string, format: uuid }
+                        order_index: { type: integer }
+                        type: { type: string, enum: [instructional, activity] }
+                        activity_type:
+                          type: string
+                          enum: [multiple_choice, fill_blank, flashcard, open_ended, matching]
+                        content: { type: object }
+                        image_url: { type: string, nullable: true }
+        "402": { description: No AI key configured }
+
+  /rest/v1/lesson_attempts:
+    patch:
+      summary: Save progress / resume position for an attempt
+      parameters:
+        - in: query
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                current_slide_index: { type: integer }
+                score: { type: number, nullable: true }
+                completed_at: { type: string, format: date-time, nullable: true }
+      responses:
+        "200": { description: Attempt updated }
+```
+
+Example request — generate a lesson:
+
+```json
+POST /functions/v1/generate-lesson
+{ "document_id": "f3a1...", "composition": "both" }
+```
+
+Example response (truncated):
+
+```json
+{
+  "lesson_id": "9c22...",
+  "slides": [
+    { "id": "s1", "order_index": 0, "type": "instructional", "content": { "title": "Photosynthesis", "body": "..." }, "image_url": "https://.../fig1.webp" },
+    { "id": "s2", "order_index": 1, "type": "activity", "activity_type": "multiple_choice", "content": { "question": "...", "options": ["A","B","C"] } }
+  ]
+}
+```
 
 ---
 
 ## 5. Historias de Usuario
 
-> Documenta 3 de las historias de usuario principales utilizadas durante el desarrollo, teniendo en cuenta las buenas prácticas de producto al respecto.
+**Historia de Usuario 1 — Authentication**
 
-**Historia de Usuario 1**
+As a user, I want to sign up, log in, and log out securely, so that my documents and lessons are private to me and available whenever I return.
+Acceptance: a user can create an account (email/password) and log in and out via Supabase Auth; a session persists across app restarts until logout; while logged in the user sees only their own data (enforced by row-level security) and a logged-out user cannot access any account data; invalid credentials show a clear error.
 
-**Historia de Usuario 2**
+**Historia de Usuario 2 — Generate a lesson from a PDF**
 
-**Historia de Usuario 3**
+As a learner, I want to upload a PDF, choose whether the lesson is instructional-only, activity-only, or both, and have the app generate a lesson, so that I can start studying without any manual prep.
+Acceptance: a text+image PDF produces an ordered deck of typed slides honoring the chosen composition; generation progress is shown; a clear error appears if the PDF can't be parsed.
+
+**Historia de Usuario 3 — Study and self-test with immediate feedback**
+
+As a learner, I want to move through slides one at a time and answer activities (multiple choice, fill-in-the-blank, flashcards, open-ended, matching) with immediate feedback, so that I learn the material and know whether I understood it.
+Acceptance: each activity type renders and grades correctly; relevant extracted images render alongside slides; an end-of-lesson score is shown for auto-gradable activities.
+
+**Historia de Usuario 4 — Resume and retake to measure learning gain**
+
+As a learner, I want to leave a lesson partway through and return to the exact slide I left off, and later retake it, so that I never lose my place and can see my improvement.
+Acceptance: position is persisted server-side and resumes across logout/login and devices; answered activities retain state; a retake records a new score so improvement (learning gain) is visible.
 
 ---
 
 ## 6. Tickets de Trabajo
 
-> Documenta 3 de los tickets de trabajo principales del desarrollo, uno de backend, uno de frontend, y uno de bases de datos. Da todo el detalle requerido para desarrollar la tarea de inicio a fin teniendo en cuenta las buenas prácticas al respecto. 
+**Ticket 1 — Authentication: sign up / log in / log out (R5)**
 
-**Ticket 1**
+Implement authentication with Supabase Auth across the Expo client (web + native): account creation (email/password), login, logout, and a persisted session, plus the auth-gated routing that protects the rest of the app.
+Tasks: configure Supabase Auth; build sign-up / login / logout screens; persist and restore the session on app start; protect authenticated routes and redirect unauthenticated users; surface clear errors for invalid credentials. Establish the `auth.uid()` foundation that later RLS policies (Ticket 4) build on.
+Acceptance: a user can sign up, log in, and log out; the session survives an app restart until logout; unauthenticated users cannot reach account screens; invalid credentials show a clear error. Definition of done: works on web and mobile viewport, with tests for the auth flow.
 
-**Ticket 2**
+**Ticket 2 — Backend: PDF content extraction Edge Function (R1, Phase 0)**
 
-**Ticket 3**
+Implement a Supabase Edge Function (Deno) that, given an uploaded PDF in Storage, extracts all selectable text and embedded images across every page, downscales/recompresses the images, persists them to Storage, and writes text + image metadata (page, position) to the database.
+Tasks: research spike comparing liteparse vs. alternatives for text+image+position and scanned-PDF detection; implement extraction; image downscaling; populate `documents`/`extracted_images`; error paths for scanned/oversized PDFs.
+Acceptance: matches R1 criteria (whole-document, mixed pages in order, graceful errors). Definition of done: function deployed, unit + sample-PDF tests passing.
+
+**Ticket 3 — Frontend: Lesson player with activities and image rendering (R3/R4)**
+
+Build the cross-platform lesson player in React Native + Expo: slide-by-slide navigation, visible progress, responsive image rendering, and the five activity widgets with immediate feedback and grading.
+Tasks: player shell + navigation; instructional slide renderer; activity widgets (multiple choice, fill-blank, flashcard, open-ended, matching via tap-to-select-two); image scaling; results summary (score / completion state).
+Acceptance: works on web and mobile viewport; matching uses tap-to-select-two (no drag-drop); image-less slides render text-only.
+
+**Ticket 4 — Database: schema, RLS, and progress/resume (R5/R7/R9)**
+
+Create migrations for `documents`, `extracted_images`, `lessons` (with `slides` jsonb), `lesson_attempts` (with `answers` jsonb), and `user_ai_keys`, with row-level security so each user only accesses their own rows; support resume via `current_slide_index` and scoring via the `answers` JSON.
+Tasks: SQL migrations; RLS policies (`user_id = auth.uid()`); indexes; seed data; verify resume + retake flows persist correctly.
+Acceptance: a logged-out user cannot read another user's lessons; resume returns to the exact slide; retake records a new score.
 
 ---
 
 ## 7. Pull Requests
 
-> Documenta 3 de las Pull Requests realizadas durante la ejecución del proyecto
+_To be completed during development. Planned PRs map to the tickets above:_
 
-**Pull Request 1**
+**Pull Request 1** — Authentication: sign up / log in / log out (Ticket 1).
 
-**Pull Request 2**
+**Pull Request 2** — Backend: PDF content extraction Edge Function (Ticket 2).
 
-**Pull Request 3**
+**Pull Request 3** — Frontend: lesson player with activities and image rendering (Ticket 3).
 
+**Pull Request 4** — Database schema, RLS, and progress/resume (Ticket 4).


### PR DESCRIPTION
Add product documentation: PRD, README and prompts log
Adds the planning and documentation deliverables for AI Study Buddy (PDF → AI-generated lesson app):

PRD.md — full product requirements: problem, goals/non-goals, user stories, P0–P2 requirements, success metrics, resolved decisions, open questions, and phased timeline.
readme.md — project deliverable: product overview, architecture + diagrams, data model, API spec, user stories, and work tickets.
prompts.md — verbatim log of the prompts used to produce the docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive PRD for AI Study Buddy MVP, detailing end-to-end PDF-to-lesson behavior, requirements, metrics, and rollout plan
  * Replaced the template README with a complete overview including architecture diagrams, API specification, and concrete implementation-focused user stories
  * Expanded prompts documentation with verbatim, fully populated prompt text and added an additional iteration/review prompt section
* **Chores**
  * Updated `.gitignore` to ignore additional editor and macOS artifacts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->