### PR TITLE
feature-entrega2-MC-FB: add prompts.md and readme.md

### DIFF
--- a/prompts.md
+++ b/prompts.md
@@ -1,6 +1,22 @@
-> Detalla en esta sección los prompts principales utilizados durante la creación del proyecto, que justifiquen el uso de asistentes de código en todas las fases del ciclo de vida del desarrollo. Esperamos un máximo de 3 por sección, principalmente los de creación inicial o  los de corrección o adición de funcionalidades que consideres más relevantes.
-Puedes añadir adicionalmente la conversación completa como link o archivo adjunto si así lo consideras
+**Estructura de sesiones:** El proyecto se desarrolló en 3 sesiones de trabajo (20+ prompts). La Sesión 1 cubrió la definición inicial del producto con el agente Analyst de BMAD. La Sesión 2 generó la documentación técnica completa via el agente `doc-generator`. La Sesión 3 fue una revisión arquitectónica crítica que derivó en decisiones de scope y adopción de estándares 2026; los prompts de esa sesión son los más representativos y los que se detallan con mayor profundidad en este documento.
 
+> **Contexto de la Sesión 3 — lista de recomendaciones referenciada en este documento:** Al inicio de esa sesión el asistente entregó una revisión crítica del stack organizada en dos bloques numerados. Los "puntos" mencionados en los prompts de las secciones 2.x corresponden a la siguiente lista:
+>
+> *Cambios por alcance del MVP (2 founders, MVP):*
+> 1. Celery + Redis es overkill → reemplazar por ARQ (async-nativo, mismo Redis) + cron de Railway para jobs programados
+> 2. Offline-first es el mayor inflador de alcance del MVP → diferir Service Workers + IndexedDB a Fase 2; comprometer sólo cache read-only en Fase 1
+> 3. Dos clouds (Vercel + Railway) duplican la operación → consolidar todo en un único proyecto Railway
+> 4. JWT + refresh tokens en Redis para staff es complejidad temprana → evaluar cookies httpOnly opacas o auth managed (Clerk / WorkOS / Supabase Auth)
+> 5. No construir el calendario ni la data grid a mano → Schedule-X o FullCalendar para agenda; TanStack Table para grids
+>
+> *Cambios por estándares 2026:*
+> 6. Prompt caching de Anthropic desde el día uno (~80% de ahorro en tokens cacheados)
+> 7. Output estructurado con Pydantic + tool use en lugar de JSON suelto
+> 8. Defensa en profundidad para multi-tenancy: PostgreSQL Row-Level Security (RLS) + suite de tests de aislamiento bloqueante en CI
+> 9. Observabilidad: Sentry + Pydantic Logfire / OpenTelemetry + PostHog
+> 10. Testing E2E mínimo del flujo IA con Playwright + snapshot tests del prompt enviado a Claude (syrupy)
+> 11. Si la migración mobile está comprometida, usar Expo desde el día uno (Expo Router + Tamagui o React Native Web)
+> 12. Selección de modelo por tarea: `claude-haiku-4-5` para inputs cortos/limpieza; `claude-sonnet-4-6` para inputs largos o multimodales
 
 ## Índice
 
@@ -16,11 +32,29 @@ Puedes añadir adicionalmente la conversación completa como link o archivo adju
 
 ## 1. Descripción general del producto
 
-**Prompt 1:**
+**Prompt 1:** *(Sesión 1 — definición inicial, rol Analyst BMAD)*
 
-**Prompt 2:**
+> "Quiero construir @docs/idea-inicial.md — Actuar como el agente Analyst de BMAD"
 
-**Prompt 3:**
+Disparó el cuestionario inicial del Analyst (10 preguntas sobre piloto, modelo SaaS, roles, notificaciones, exportación, voz, offline, validación IA, stack). Las respuestas al cuestionario fijaron las decisiones fundacionales del producto: SaaS multi-clínica desde el inicio, 3 roles staff + 1 portal cliente, email primero / WhatsApp después, validación IA con edición opcional, stack React + FastAPI + Postgres + Whisper + Claude, soporte offline requerido (luego diferido a Fase 2).
+
+**Prompt 2:** *(Sesión 3 — scope IA acotado al MVP)*
+
+> "dadas las sugerencias del stack tecnologico revisado y los cambios propuestos, para los puntos:
+> 6. Prompt caching de Anthropic desde el día uno (cuts ~80% de tokens cacheados).
+> 7. Output estructurado con Pydantic + tool use en lugar de JSON suelto.
+>
+> la idea que tenemos es utilizar un modelo de IA para en funcion de una historia clinica con un formato y estructura definidos, se complete la misma con la informacion transcrita de el audio/imagen/texto que carge el especialista. no se busca por ahora que el modelo genere diagnosticos o sugerencias para incluir en la historia clinica. se podria dejar para una etapa posterior. necesito que modifiques los archivos del proyecto para reflejar esta decision."
+
+Cambio de alcance fundamental para el value proposition. La IA pasa de "genera la historia clínica" a "estructura los campos predefinidos". El cambio se propagó a 8 archivos: features, RFs, RNFs, user stories, schema Pydantic `ClinicalRecordExtraction` (sin `diagnosis` ni `treatment_suggestion`), Use Case 1, riesgos. Define la promesa real del MVP frente a las clínicas piloto.
+
+**Prompt 3:** *(Sesión 3 — diferimiento de offline y Portal del Cliente)*
+
+> "ejecutame paso a paso los siguientes puntos:
+> - del punto 2 de los cambios sugeridos por alcance ('Offline-first es el mayor inflador de alcance del MVP — Service Workers + IndexedDB + cola de mutaciones + last-write-wins es un proyecto en sí mismo'), la idea es posponer la funcionalidad o soporte offline para una fase posterior del proyecto, por lo tanto modifica todos los archivos del proyecto, eliminando toda referencia a dicha funcionalidad y componentes o estructuras que la conformen.
+> - el entidad de cliente, junto con el portal al que accede el mismo, tambien lo pensamos para una fase 1.5 del proyecto. contempla esta decision modificando los archivos del proyecto donde se mencione dicha funcionalidad."
+
+Recorte de alcance del MVP. Soporte offline → Fase 2. Portal del Cliente → Fase 1.5. El diseño se mantuvo documentado en todos los archivos pero marcado claramente como diferido, para reincorporarse sin reescritura cuando llegue su iteración.
 
 ---
 
@@ -28,98 +62,253 @@ Puedes añadir adicionalmente la conversación completa como link o archivo adju
 
 ### **2.1. Diagrama de arquitectura:**
 
-**Prompt 1:**
+**Prompt 1:** *(Sesión 2 — generación inicial via doc-generator)*
 
-**Prompt 2:**
+> "@ia-agents/agents/doc-generator.md genera la documentacion del proyecto"
 
-**Prompt 3:**
+Disparó el agente `doc-generator` (rol Senior Product Manager). Produjo el PRD completo con sección 11 (System Design) + sección 12 (C4: Context, Container, Component) usando 9 diagramas Mermaid.
+
+**Prompt 2:** *(Sesión 3 — corrección de superposiciones en C4)*
+
+> "los otros 3 diagramas c4, no se visualizan correctamente, tienen superpociciones en algunos de sus componentes"
+
+Diagnóstico: la sintaxis nativa `C4Context` / `C4Container` / `C4Component` de Mermaid tiene auto-layout inmaduro que produce superposiciones. Se reescribieron los 3 diagramas usando `flowchart` + `subgraph` + `classDef` con la paleta oficial de C4 (navy person, azul system, azul claro component, gris ext, cilindro dbms). Se actualizó `ia-agents/rules/diagram-conventions.md` para que futuras generaciones eviten el problema desde el principio.
+
+**Prompt 3:** *(Sesión 3 — Code View C4 que faltaba)*
+
+> "en la generacion de documentacion, puntualmente del prd, en la seccion de diagramas C4 falto generar el diagrama 'Code'. genera el diagrama faltante"
+
+Se agregó *Figure 10* (`classDiagram` Mermaid) zoomeando el AI Orchestrator: jerarquía `AIProvider` (strategy pattern), `WhisperTranscriber`, `ContextBuilder`, `ModelSelector`, `AIService`, `ClinicalRecordExtraction` (Pydantic), `AuditLogger` y modelos SQLAlchemy.
 
 ### **2.2. Descripción de componentes principales:**
 
-**Prompt 1:**
+**Prompt 1:** *(Sesión 3 — revisión inicial del stack)*
 
-**Prompt 2:**
+> "a partir de @docs/ que opinas de la arquitectura y stack elegidos para desarrollar este sistema, que cambiarias en funcion del alcance del proyecto y de los estandares actuales?"
 
-**Prompt 3:**
+Revisión crítica del stack en tres bloques (aciertos / cambios por alcance / estándares 2026). Identificó: Celery + Redis es overkill para 2 founders → ARQ + cron Railway; Vercel + Railway → Railway-solo; construir agenda/grids → Schedule-X + TanStack Table.
+
+**Prompt 2:** *(Sesión 3 — profundización de cada herramienta)*
+
+> "genera un archivo info.md dentro de @docs/ que explique y profundice en cada una de las herramientas de la primera seccion de la respuesta anterior"
+
+Creó `docs/info.md` con 4 secciones (Backend, Frontend, patrones de datos, patrones de IA) explicando cada herramienta: qué es, por qué es la elección correcta **para este proyecto**, ejemplo de código aplicado al dominio veterinario, buenas prácticas, riesgos.
+
+**Prompt 3:** *(Sesión 3 — aplicación de cambios al stack)*
+
+> "de los cambios de alcance sugeridos en la sesión (puntos 1, 3 y 5), modifica los archivos del proyecto para considerar los cambios: Celery → ARQ + cron Railway; Vercel + Railway → Railway solo; Construir agenda/grids vs librerías; no apliques el cambio de no utilizar jwt + redis"
+
+Propagó las tres decisiones de simplificación a CLAUDE.md, README.md, architecture.md, prd.md, entrega1/readme.md. Mantuvo JWT + Redis como pidió el usuario.
 
 ### **2.3. Descripción de alto nivel del proyecto y estructura de ficheros**
 
-**Prompt 1:**
+**Prompt 1:** *(Sesión 2 — scaffolding documentado)*
 
-**Prompt 2:**
+> "@ia-agents/agents/doc-generator.md genera la documentacion del proyecto"
 
-**Prompt 3:**
+(Mismo prompt que 2.1 — la estructura de ficheros se generó como parte de architecture.md sección 2 y 3.)
+
+**Prompt 2:** *(Sesión 3 — Expo + Tamagui desde el día 1)*
+
+> "de los cambios sugeridos para estándares 2026, los siguientes puntos los vamos a adoptar, modifica todos los archivos del proyecto para incorporar dichas sugerencias:
+> 8. Defensa en profundidad para multi-tenancy: PostgreSQL Row-Level Security (RLS) además del filtro en queries; tests de regresión que validen aislamiento entre clínicas/clientes.
+> 10. Testing E2E mínimo del flujo IA con Playwright; snapshot tests del prompt enviado a Claude.
+> 11. Si la migración mobile está comprometida, usar Expo desde el día uno (Expo Router + Tamagui o React Native Web)."
+
+Cambió la estructura de `frontend/` de "React SPA reescribible a React Native" a "Expo Router + Tamagui con build web vía React Native Web desde el primer componente". Capas `services/` y `store/` portables sin reescritura.
 
 ### **2.4. Infraestructura y despliegue**
 
-**Prompt 1:**
+**Prompt 1:** *(Sesión 3 — consolidación en Railway)*
 
-**Prompt 2:**
+> "Vercel + Railway → Railway solo"
 
-**Prompt 3:**
+Reescritura completa de la sección 7 de architecture.md y figura 2 de entrega1/readme.md. Todos los servicios (frontend estático, backend, ARQ worker, cron, Postgres, Redis) viven en un único proyecto Railway. Reverse proxy interno elimina CORS frontend-backend. Removidas todas las referencias a Vercel y a Render como alternativas.
+
+**Prompt 2:** *(Sesión — estimación de billing)*
+
+> "en funcion de las herramientas y tecnologias elegidas, realizame una estimacion de billing para el proyecto como un mvp funcional de pocos usuarios"
+
+Producía tres escenarios (piloto / MVP / validación inicial) con tabla detallada por servicio. Total para MVP de 3 clínicas: ~U$ 55–70/mes. Identificó que el cuello de botella económico no es la infraestructura sino el tiempo de los founders.
+
+**Prompt 3:** *(Sesión — hosting local para piloto inicial)*
+
+> "para una prueba piloto inicial, no podriamos hostear todo local?"
+
+Respuesta en tres escenarios: pre-piloto Docker Compose local ($0), piloto real con mini-PC on-premise en la clínica (~$400 one-time + $0/mes), VPS Hetzner €4/mes como alternativa cloud económica. Conclusión: migrar a Railway cuando haya 2–3 clínicas pagando.
 
 ### **2.5. Seguridad**
 
-**Prompt 1:**
+**Prompt 1:** *(Sesión 3 — RLS como defensa en profundidad)*
 
-**Prompt 2:**
+> "de los cambios sugeridos para estándares 2026, los siguientes puntos los vamos a adoptar, modifica todos los archivos del proyecto para incorporar dichas sugerencias:
+> 8. Defensa en profundidad para multi-tenancy: PostgreSQL Row-Level Security (RLS) además del filtro en queries; tests de regresión que validen aislamiento entre clínicas/clientes.
+> 10. Testing E2E mínimo del flujo IA con Playwright; snapshot tests del prompt enviado a Claude.
+> 11. Si la migración mobile está comprometida, usar Expo desde el día uno (Expo Router + Tamagui o React Native Web)."
 
-**Prompt 3:**
+Incorporó RLS a architecture.md §4 (setup completo: `ENABLE/FORCE ROW LEVEL SECURITY`, policy por tabla, `SET LOCAL app.clinic_id`, usuarios `app_runtime` + `app_admin`). En data-model.md nueva sección con SQL. En prd.md RNF-011 (RLS) y RNF-012 (suite de aislamiento bloqueante en CI).
+
+**Prompt 2:** *(Sesión — entidades de auditoría)*
+
+> "es buena idea/practica incorporar al modelo de datos una entidad que registre los logs/historial de las consultas, transacciones, etc a la DB?" → "si, aplicame los cambios"
+
+Incorporó dos tablas append-only: `audit_log` (mutaciones con diff JSONB, auto-poblada via SQLAlchemy event listener) y `clinical_record_access_log` (lecturas de historias clínicas para cumplir Ley 25.326). Append-only enforced en DB (`REVOKE UPDATE, DELETE`). Retención 7 años + anonimización (no borrado). Restringido a rol `admin`.
 
 ### **2.6. Tests**
 
-**Prompt 1:**
+**Prompt 1:** *(Sesión 3 — Playwright + syrupy)*
 
-**Prompt 2:**
+> "de los cambios sugeridos para estándares 2026, los siguientes puntos los vamos a adoptar, modifica todos los archivos del proyecto para incorporar dichas sugerencias:
+> 8. Defensa en profundidad para multi-tenancy: PostgreSQL Row-Level Security (RLS) además del filtro en queries; tests de regresión que validen aislamiento entre clínicas/clientes.
+> 10. Testing E2E mínimo del flujo IA con Playwright; snapshot tests del prompt enviado a Claude.
+> 11. Si la migración mobile está comprometida, usar Expo desde el día uno (Expo Router + Tamagui o React Native Web)."
 
-**Prompt 3:**
-
----
-
-### 3. Modelo de Datos
-
-**Prompt 1:**
-
-**Prompt 2:**
-
-**Prompt 3:**
+Stack de testing extendido en architecture.md §3: pytest + pytest-asyncio + **Playwright** (E2E del flujo IA end-to-end) + **syrupy** (snapshot del prompt completo + schema enviado a Claude). RNF-013 y RNF-014 en el PRD.
 
 ---
 
-### 4. Especificación de la API
+## 3. Modelo de Datos
 
-**Prompt 1:**
+**Prompt 1:** *(Sesión 2 — generación inicial)*
 
-**Prompt 2:**
+> "@ia-agents/agents/doc-generator.md genera la documentacion del proyecto"
 
-**Prompt 3:**
+Generó el ERD inicial en docs/data-model.md con las 10 entidades principales: clinics, users, clients, pets, appointments, appointment_notifications, clinical_records, clinical_attachments, clinical_records_ai, vaccinations + entidades Fase 2.
+
+**Prompt 2:** *(Sesión — separación users vs clients)*
+
+> "se indica la creacion de dos entidades, 'usuarios' y 'clientes', entindo que se hace asi porque se separa el modo de autenticacion respecto a los 'usuarios' propios de la clinica, pero son practicamente iguales. Que justificacion encontras para tener esas 2 entidades y no unificarlas?"
+
+Justificación documentada: distintos FKs (created_by → users, owns → clients), distintos ciclos de vida (staff contratado/despedido vs cliente con relación continua), distintos modelos de auth (JWT staff vs JWT portal en Fase 1.5), RLS más simple con tablas separadas. La alternativa "identity + profiles" se reservó para refactor futuro si aparecen ≥10 casos de "staff que también es cliente".
+
+**Prompt 3:** *(Sesión 3 — schema IA + Fase 1.5)*
+
+> "dadas las sugerencias del stack tecnologico revisado y los cambios propuestos, para los puntos:
+> 6. Prompt caching de Anthropic desde el día uno (cuts ~80% de tokens cacheados).
+> 7. Output estructurado con Pydantic + tool use en lugar de JSON suelto.
+>
+> no se busca por ahora que el modelo genere diagnosticos ni sugerencias en la historia clinica. Adicionalmente, el entidad de cliente, junto con el portal al que accede el mismo, lo pensamos para una fase 1.5 del proyecto."
+
+Tabla `clinical_records_ai` reescrita con `schema_version`, `ai_structured_output` (sin diagnosis/treatment en MVP), `cache_hit_tokens`, `cache_write_tokens`. Tabla `clients` partida en "Fase 1 — campos requeridos" + "Fase 1.5 — campos del Portal" (`portal_enabled`, `password_hash`, `is_active`, `last_login_at`).
 
 ---
 
-### 5. Historias de Usuario
+## 4. Especificación de la API
 
-**Prompt 1:**
+**Prompt 1:** *(Sesión 2 — endpoints iniciales)*
 
-**Prompt 2:**
+> "con toda la informacion de @docs\ completa el archivo @entrega1/readme.md respetando el formato tipo cuestionario, completando los puntos que puedas sin inventar nada."
 
-**Prompt 3:**
+Generó la primera versión de la spec OpenAPI con 3 endpoints: transcripción IA, historial clínico, creación de turno.
+
+**Prompt 2:** *(Sesión 3 — endpoint `/ai/extract-record`)*
+
+> "dadas las sugerencias del stack tecnologico revisado y los cambios propuestos, para los puntos:
+> 6. Prompt caching de Anthropic desde el día uno (cuts ~80% de tokens cacheados).
+> 7. Output estructurado con Pydantic + tool use en lugar de JSON suelto.
+>
+> la idea que tenemos es utilizar un modelo de IA para que, en funcion de una historia clinica con un formato y estructura definidos, se complete la misma con la informacion transcrita de el audio/imagen/texto que cargue el especialista. necesito que modifiques los archivos del proyecto para reflejar esta decision."
+
+El endpoint cambió de `/ai/generate-record` (genera todo) a `/ai/extract-record` (estructura los campos extraíbles). Response schema actualizado: `consultation_reason`, `symptoms`, `weight_kg`, `temperature_c`, `medication_taken` + `diagnosis: null`, `treatment: null` con descripción explícita "Siempre null en MVP — completar manualmente".
+
+**Prompt 3:** *(Sesión — completar entrega1 con OpenAPI actualizado)*
+
+> "ahora necesito que con la informacion actual del proyecto y de los archivos incluidos en el, me completes los documentos @entrega1/prompts.md y @entrega1/readme.md"
+
+Regeneró la spec OpenAPI con los tres endpoints del flujo IA reflejando todas las decisiones de Sesión 3 (alcance acotado, prompt caching, snapshot tests, RLS, auditoría automática).
+
+---
+
+## 5. Historias de Usuario
+
+**Prompt 1:** *(Sesión 2 — generación inicial)*
+
+> "@ia-agents/agents/doc-generator.md genera la documentacion del proyecto"
+
+Generó 32 historias de usuario distribuidas en 10 módulos (Autenticación, Clientes, Mascotas, Historia Clínica, IA, Turnos, Notificaciones, Vacunación, Reportes, Offline).
+
+**Prompt 2:** *(Sesión 3 — ajuste de US-013/014/015 por scope IA)*
+
+> "dadas las sugerencias del stack tecnologico revisado y los cambios propuestos, para los puntos:
+> 6. Prompt caching de Anthropic desde el día uno (cuts ~80% de tokens cacheados).
+> 7. Output estructurado con Pydantic + tool use en lugar de JSON suelto.
+>
+> no se busca por ahora que el modelo genere diagnosticos ni sugerencias terapeuticas. reescribí las historias de usuario del módulo de historia clínica asistida por IA para reflejar este alcance acotado."
+
+Las historias del Módulo 4 (US-013 a US-016) se reescribieron: ya no piden "obtener la historia clínica generada" sino "que la app complete los campos predefinidos a partir de lo dictado"; los campos `diagnóstico` y `tratamiento` quedan vacíos en el pre-fill; US-015 (imagen) pasa de "diagnóstico sugerido" a "descripción objetiva de lo visible".
+
+**Prompt 3:** *(Sesión — incorporación de historias de auditoría)*
+
+> "es buena idea/practica incorporar al modelo de datos una entidad que registre los logs/historial [...] si, aplicame los cambios"
+
+Nuevo Módulo 12 con tres historias: US-039 (Admin ve historial de cambios con diff campo-por-campo), US-040 (Admin ve registro de accesos a una historia clínica), US-041 (Admin exporta auditoría de un período a Excel/CSV).
 
 ---
 
 ### 6. Tickets de Trabajo
 
-**Prompt 1:**
+**Prompt 1:** *(Sesión de generación de tickets — invocación del user-story-agent + estrategia modular)*
 
-**Prompt 2:**
+> "genera los tickets de trabajo para cada historia de usuario en `@docs/user-stories.md`, aplicando el formato BDD con criterios Dado que / Cuando / Entonces, evaluación INVEST y estimación de talla S/M/L"
 
-**Prompt 3:**
+El agente `user-story-agent` detectó que procesar las 41 historias de usuario en una sola invocación superaría el límite de tokens de output (~32K). Se adoptó la estrategia **módulo por módulo con ediciones quirúrgicas**: cada agente recibe un único módulo, lee la sección correspondiente del archivo y usa `old_string/new_string` para insertar los tickets directamente antes del separador `---` de cada US, sin reescribir el archivo completo. Esto permitió procesar los 11 módulos (US-001 a US-041 más módulos diferidos) en rondas de agentes paralelos independientes.
+
+Resultado: 82 tickets insertados (41 BE + 41 FE), con 3 escenarios BDD por ticket (happy path, edge case, error) y evaluación INVEST completa. Los tickets de los módulos diferidos (Portal del Cliente — Fase 1.5, Offline — Fase 2) recibieron `I⚠️` en INVEST para señalar que su independencia está condicionada a la implementación de la Fase 1.
+
+**Prompt 2:** *(Sesión — extensión del modelo a 5 capas de desarrollo)*
+
+> "@.claude/agents/user-story-agent.md indica al agente que se debe generar user story y tickets de todo el espectro de desarrollo, no solo backend y frontend"
+
+El agente `user-story-agent` solo generaba tickets `-BE` y `-FE`. Se actualizaron ambas copias del agente (`.claude/agents/user-story-agent.md` y `ia-agents/agents/user-story-agent.md`) para definir el modelo de 5 capas:
+
+| Sufijo | Capa | Cuándo generarlo |
+|---|---|---|
+| `-BE` | Backend | endpoint, lógica de negocio, worker ARQ, cron job |
+| `-FE` | Frontend | pantalla, componente, hook, flujo UI |
+| `-DB` | Base de datos | migración Alembic nueva, tabla, índice, RLS policy, append-only |
+| `-INFRA` | Infraestructura | Railway env vars, cron schedule, CI/CD, Docker, secrets, S3 |
+| `-AI` | IA / Integración | prompt nuevo, schema Pydantic de extracción, selección de modelo, prompt caching |
+
+La regla de decisión incorporada: crear ticket de capa separado solo cuando ese trabajo puede asignarse a una persona distinta, tiene criterios de aceptación propios y puede testearse independientemente. El workflow del agente se extendió con los pasos 6 ("Para cada capa involucrada → generar ticket con sufijo correcto") y 7 ("Marcar dependencias entre tickets").
+
+**Prompt 3:** *(Sesión — aplicación retroactiva de los nuevos criterios a los 82 tickets existentes)*
+
+> "@.claude/agents/user-story-agent.md modifica los tickets generados en `@docs/user-stories.md` considerando los nuevos criterios"
+
+Se analizaron los 82 tickets existentes aplicando el criterio de las 5 capas. Se identificaron 9 user stories que requieren tickets adicionales de base de datos, infraestructura o IA — aquellos donde el trabajo de esas capas es suficientemente autónomo para asignarse y testearse independientemente:
+
+| Ticket nuevo | US | Justificación |
+|---|---|---|
+| `US-001-DB` | Registro de clínica | Migración inicial con setup de RLS, roles `app_runtime`/`app_admin` y FORCE ROW LEVEL SECURITY — prerequisito de todo el sistema |
+| `US-001-INFRA` | Registro de clínica | Variables de entorno Railway + `.env.example` para todos los servicios del MVP |
+| `US-013-DB` | Voz → campos clínicos | Tabla `clinical_records_ai` append-only con REVOKE + índice compuesto — independiente del endpoint BE |
+| `US-013-AI` | Voz → campos clínicos | System prompt de extracción, schema Pydantic `ClinicalRecordExtraction`, selección haiku/sonnet, prompt caching + tests syrupy bloqueantes |
+| `US-014-AI` | Audio uploaded | Verificación de reutilización del pipeline + guard de selección de modelo para audio upload |
+| `US-015-AI` | Imagen → síntomas | Prompt Vision para `claude-sonnet-4-6`, campo `image_observations`, guard que prohíbe haiku en flujo imagen |
+| `US-021-INFRA` | Recordatorios de turno | Cron job Railway `0 8 * * *` + `RESEND_API_KEY` — configuración independiente del endpoint de envío |
+| `US-039-DB` | Historial de cambios | Tabla `audit_log` append-only + listener SQLAlchemy `after_flush` + índices compuestos para queries de auditoría |
+| `US-040-DB` | Registro de accesos | Tabla `clinical_record_access_log` append-only con REVOKE para trazabilidad de lecturas (Ley 25.326) |
+
+Total final: **91 tickets** (41 BE · 41 FE · 4 DB · 2 INFRA · 3 AI) · 41 US cubiertas · Fase 1 MVP: 65 tickets · Fase 1.5 + Fase 2: 26 tickets. La tabla de resumen al final de `docs/user-stories.md` se actualizó con las nuevas entradas y los totales corregidos.
 
 ---
 
-### 7. Pull Requests
+## 7. Pull Requests
 
-**Prompt 1:**
+**Prompt 1:** *(Sesión 1 — flujo inicial de PRs)*
 
-**Prompt 2:**
+> "podes crearme una rama 'docs', hacer un commit con todo lo realizado y luego realizar el push? siempre consultandome antes de ejecutar algun comando"
 
-**Prompt 3:**
+Creación de la rama `docs` y primer push a `origin/docs`. Establecimiento de la convención de hacer todos los commits de documentación en esa rama hasta validar con tutores.
+
+**Prompt 2:** *(Sesión 3 — commit de la revisión arquitectónica completa)*
+
+> "realiza un commit con todos los cambios realizados, agrega un comentario descriptivo y subi los cambios a la rama docs"
+
+Disparó la creación del commit `aeeacff docs: revise architecture for MVP scope and 2026 standards` (11 archivos, +1994/−409 líneas) agrupando todos los cambios de Sesión 3 en cuatro bloques temáticos (scope decisions, infrastructure simplifications, AI scope and tooling, standards 2026). Push exitoso a `origin/docs`.
+
+**Prompt 3:** *(Sesión — patrón de PRs documentadas)*
+
+> Convención implícita establecida en toda la sesión: cada cambio relevante sobre los docs se acompaña con un mensaje de commit estructurado siguiendo conventional commits (`docs:`, `feat:`, `fix:` prefixes), y los cambios grandes se agrupan por temática para que el `git log` cuente la historia del proyecto sin necesidad de leer cada diff.
+
+Los PRs reales (cuando inicie Fase 1 con scaffolding de código) seguirán este patrón: PRs chicas y enfocadas, mensajes descriptivos con bloques temáticos, CI bloqueante con suite de tests de aislamiento RLS + snapshot del prompt antes del merge.

--- a/prompts.md
+++ b/prompts.md
@@ -1,273 +1,273 @@
-**Estructura de sesiones:** El proyecto atravesó dos grandes etapas. **Etapa de documentación (Sesiones 1–3):** definición del producto con el agente Analyst de BMAD, generación de la documentación técnica completa vía el agente `doc-generator`, y una revisión arquitectónica crítica que fijó el alcance del MVP y la adopción de estándares 2026. **Etapa de implementación (Sesiones 4–28):** generación de tickets por capa, scaffolding, configuración del flujo `/implement-us` y desarrollo iterativo de las User Stories (US-001 a US-014, US-017 a US-023 y US-DASH), cada una con su PR a `dev`. Este documento selecciona, por cada sección de la entrega, los prompts **más relevantes** de ambas etapas. El log cronológico íntegro vive en [docs/prompts/prompts.md](../docs/prompts/prompts.md).
+**Session structure:** The project went through two major stages. **Documentation stage (Sessions 1–3):** product definition with BMAD's Analyst agent, generation of the complete technical documentation via the `doc-generator` agent, and a critical architectural review that fixed the MVP scope and the adoption of 2026 standards. **Implementation stage (Sessions 4–28):** ticket generation by layer, scaffolding, configuration of the `/implement-us` flow, and iterative development of the User Stories (US-001 to US-014, US-017 to US-023 and US-DASH), each with its PR to `dev`. This document selects, for each section of the delivery, the **most relevant** prompts from both stages. The full chronological log lives in [docs/prompts/prompts.md](../docs/prompts/prompts.md).
 
-> **Flujo de desarrollo (Sesiones 6–8).** A partir de la Sesión 6 se construyó el comando `/implement-us <issue>`, que orquesta el ciclo completo de una US: el agente `planning-specialist` genera `docs/changelog/US-XXX.md` (criterios de done, archivos esperados, contrato de interfaz, riesgos, scope y dependencias por ticket); luego se despachan agentes en orden **INFRA → DB → BE → FE**, con `tdd-specialist` tras cada uno y consulta a Stitch MCP antes del FE. Cada ticket genera un commit (`feat(db|be|fe):`) y la US un PR a `dev`. El board de GitHub Projects recorre Todo → In Progress → In Review → Done.
+> **Development flow (Sessions 6–8).** Starting in Session 6, the `/implement-us <issue>` command was built, orchestrating the full cycle of a US: the `planning-specialist` agent generates `docs/changelog/US-XXX.md` (done criteria, expected files, interface contract, risks, scope and dependencies per ticket); then agents are dispatched in order **INFRA → DB → BE → FE**, with `tdd-specialist` after each one and a Stitch MCP consultation before the FE. Each ticket generates a commit (`feat(db|be|fe):`) and the US a PR to `dev`. The GitHub Projects board moves through Todo → In Progress → In Review → Done.
 
-> **Decisiones de implementación que divergieron del plan original** (documentadas en los prompts de abajo): email **Resend → SMTP `aiosmtplib`** (US-004); transcripción **OpenAI `whisper-1` → Groq `whisper-large-v3`** (US-013); recordatorios **48h+24h cada 15 min → un único cron diario a las 08:00 para los turnos de mañana** (US-021); alcance IA **ampliado** para extraer diagnóstico/tratamiento *cuando el veterinario los dicta explícitamente* —sin inventarlos nunca— (US-013).
+> **Implementation decisions that diverged from the original plan** (documented in the prompts below): email **Resend → SMTP `aiosmtplib`** (US-004); transcription **OpenAI `whisper-1` → Groq `whisper-large-v3`** (US-013); reminders **48h+24h every 15 min → a single daily cron at 08:00 for tomorrow's appointments** (US-021); AI scope **expanded** to extract diagnosis/treatment *when the veterinarian dictates them explicitly* —never inventing them— (US-013).
 
-## Índice
+## Index
 
-1. [Descripción general del producto](#1-descripción-general-del-producto)
-2. [Arquitectura del sistema](#2-arquitectura-del-sistema)
-3. [Modelo de datos](#3-modelo-de-datos)
-4. [Especificación de la API](#4-especificación-de-la-api)
-5. [Historias de usuario](#5-historias-de-usuario)
-6. [Tickets de trabajo](#6-tickets-de-trabajo)
+1. [Product overview](#1-product-overview)
+2. [System architecture](#2-system-architecture)
+3. [Data model](#3-data-model)
+4. [API specification](#4-api-specification)
+5. [User stories](#5-user-stories)
+6. [Work tickets](#6-work-tickets)
 7. [Pull requests](#7-pull-requests)
 
 ---
 
-## 1. Descripción general del producto
+## 1. Product overview
 
-**Prompt 1:** *(Sesión 1 — definición inicial, rol Analyst BMAD)*
+**Prompt 1:** *(Session 1 — initial definition, BMAD Analyst role)*
 
-> "Quiero construir @docs/idea-inicial.md — Actuar como el agente Analyst de BMAD"
+> "I want to build @docs/idea-inicial.md — Act as BMAD's Analyst agent"
 
-Disparó el cuestionario inicial del Analyst (10 preguntas sobre piloto, modelo SaaS, roles, notificaciones, exportación, voz, offline, validación IA, stack). Las respuestas fijaron las decisiones fundacionales: SaaS multi-clínica, 3 roles staff + portal cliente, email primero / WhatsApp después, validación IA con edición opcional, stack React + FastAPI + Postgres + Whisper + Claude.
+Triggered the Analyst's initial questionnaire (10 questions about pilot, SaaS model, roles, notifications, export, voice, offline, AI validation, stack). The answers fixed the foundational decisions: multi-clinic SaaS, 3 staff roles + client portal, email first / WhatsApp later, AI validation with optional editing, stack React + FastAPI + Postgres + Whisper + Claude.
 
-**Prompt 2:** *(Sesión 3 — scope IA acotado al MVP)*
+**Prompt 2:** *(Session 3 — AI scope narrowed to the MVP)*
 
-> "la idea que tenemos es utilizar un modelo de IA para en funcion de una historia clinica con un formato y estructura definidos, se complete la misma con la informacion transcrita de el audio/imagen/texto que carge el especialista. no se busca por ahora que el modelo genere diagnosticos o sugerencias para incluir en la historia clinica."
+> "the idea we have is to use an AI model so that, based on a clinical record with a defined format and structure, it gets filled in with the information transcribed from the audio/image/text uploaded by the specialist. for now we don't want the model to generate diagnoses or suggestions to include in the clinical record."
 
-Cambio de alcance fundamental: la IA pasa de "genera la historia clínica" a "estructura los campos predefinidos". Se propagó a 8 archivos (features, RFs, RNFs, user stories, schema `ClinicalRecordExtraction`, Use Case 1, riesgos).
+Fundamental scope change: the AI goes from "generate the clinical record" to "structure the predefined fields". It propagated to 8 files (features, FRs, NFRs, user stories, `ClinicalRecordExtraction` schema, Use Case 1, risks).
 
-**Prompt 3:** *(Sesión 27 — ampliación del alcance IA al implementarlo)*
+**Prompt 3:** *(Session 27 — AI scope expansion while implementing it)*
 
-> "probe el flujo... me transcribio los datos del audio, pero no me seteo todos los campos de la estructura" → "si" (confirma ajustar el prompt para extraer diagnosis/treatment cuando el vet los dicta)
+> "I tested the flow... it transcribed the audio data, but it didn't set all the fields of the structure for me" → "yes" (confirms adjusting the prompt to extract diagnosis/treatment when the vet dictates them)
 
-Al implementar US-013 se detectó que el prompt bloqueaba `diagnosis`/`treatment` aunque el vet los dictara. Se ajustó: el system prompt ahora extrae diagnóstico/tratamiento **si el vet los dicta explícitamente**, distingue `referred_medication` (lo que el dueño ya dio) de `treatment` (lo que indica el vet) y **nunca inventa**; el schema cambió esos campos de `None` fijo a `Optional[str]`. Matiz clave del MVP: la IA estructura lo dictado, no genera diagnósticos propios.
+While implementing US-013 it was found that the prompt blocked `diagnosis`/`treatment` even when the vet dictated them. It was adjusted: the system prompt now extracts diagnosis/treatment **if the vet dictates them explicitly**, distinguishes `referred_medication` (what the owner already gave) from `treatment` (what the vet indicates) and **never invents**; the schema changed those fields from a fixed `None` to `Optional[str]`. Key MVP nuance: the AI structures what is dictated, it does not generate its own diagnoses.
 
 ---
 
-## 2. Arquitectura del Sistema
+## 2. System Architecture
 
-### **2.1. Diagrama de arquitectura:**
+### **2.1. Architecture diagram:**
 
-**Prompt 1:** *(Sesión 2 — generación inicial vía doc-generator)*
+**Prompt 1:** *(Session 2 — initial generation via doc-generator)*
 
-> "@ia-agents/agents/doc-generator.md genera la documentacion del proyecto"
+> "@ia-agents/agents/doc-generator.md generate the project documentation"
 
-Disparó el agente `doc-generator` (rol Senior Product Manager). Produjo el PRD completo con la sección 11 (High-Level System Design) + sección 12 (C4: Context, Container, Component) usando diagramas Mermaid, base del *Figure 1* de arquitectura.
+Triggered the `doc-generator` agent (Senior Product Manager role). It produced the complete PRD with section 11 (High-Level System Design) + section 12 (C4: Context, Container, Component) using Mermaid diagrams, the basis for *Figure 1* of the architecture.
 
-**Prompt 2:** *(Sesión 3 — revisión crítica del stack)*
+**Prompt 2:** *(Session 3 — critical review of the stack)*
 
-> "a partir de @docs/ que opinas de la arquitectura y stack elegidos para desarrollar este sistema, que cambiarias en funcion del alcance del proyecto y de los estandares actuales?"
+> "based on @docs/ what do you think of the architecture and stack chosen to develop this system, what would you change based on the project scope and current standards?"
 
-Revisión en tres bloques (aciertos / cambios por alcance / estándares 2026). Identificó: Celery + Redis es overkill → ARQ + cron Railway; Vercel + Railway → Railway-solo; construir agenda/grids a mano → Schedule-X + TanStack Table; prompt caching y RLS desde el día uno.
+Review in three blocks (good choices / changes by scope / 2026 standards). It identified: Celery + Redis is overkill → ARQ + Railway cron; Vercel + Railway → Railway-only; building agenda/grids by hand → Schedule-X + TanStack Table; prompt caching and RLS from day one.
 
-**Prompt 3:** *(Sesión 3 — aplicación de los cambios de simplificación)*
+**Prompt 3:** *(Session 3 — applying the simplification changes)*
 
-> "de los cambios de alcance sugeridos: Celery → ARQ + cron Railway; Vercel + Railway → Railway solo; Construir agenda/grids vs librerías; no apliques el cambio de no utilizar jwt + redis"
+> "of the suggested scope changes: Celery → ARQ + Railway cron; Vercel + Railway → Railway only; Building agenda/grids vs libraries; don't apply the change of not using jwt + redis"
 
-Propagó las tres decisiones a CLAUDE.md, README.md, architecture.md, prd.md, redibujando el diagrama de arquitectura general. Mantuvo JWT + Redis.
+Propagated the three decisions to CLAUDE.md, README.md, architecture.md, prd.md, redrawing the general architecture diagram. Kept JWT + Redis.
 
-### **2.2. Descripción de componentes principales:**
+### **2.2. Description of main components:**
 
-**Prompt 1:** *(Sesión 3 — profundización de cada herramienta)*
+**Prompt 1:** *(Session 3 — deep dive on each tool)*
 
-> "genera un archivo info.md dentro de @docs/ que explique y profundice en cada una de las herramientas de la primera seccion de la respuesta anterior"
+> "generate an info.md file inside @docs/ that explains and goes deep into each of the tools from the first section of the previous answer"
 
-Creó `docs/info.md` con 4 secciones (Backend, Frontend, patrones de datos, patrones de IA) explicando cada componente: qué es, por qué es la elección correcta **para este proyecto**, ejemplo de código aplicado al dominio veterinario, buenas prácticas y riesgos.
+Created `docs/info.md` with 4 sections (Backend, Frontend, data patterns, AI patterns) explaining each component: what it is, why it is the right choice **for this project**, a code example applied to the veterinary domain, best practices and risks.
 
-**Prompt 2:** *(Sesión 27 — materialización del componente de IA, US-013)*
+**Prompt 2:** *(Session 27 — materialization of the AI component, US-013)*
 
 > `/implement-us 268`
 
-Materializó el componente diferenciador: el pipeline ARQ **Groq Whisper (`whisper-large-v3`) → Claude Haiku cleanup → Claude Sonnet tool use**. Decisiones reales de componente: Groq Whisper vía SDK de OpenAI con `base_url` override; el worker crea su propia sesión con `set_config` para RLS; subida del SDK `anthropic` a `0.111.0` y corrección de model IDs (`claude-haiku-4-5-20251001`, `claude-sonnet-4-6`).
+Materialized the differentiating component: the ARQ pipeline **Groq Whisper (`whisper-large-v3`) → Claude Haiku cleanup → Claude Sonnet tool use**. Real component decisions: Groq Whisper via the OpenAI SDK with a `base_url` override; the worker creates its own session with `set_config` for RLS; bumping the `anthropic` SDK to `0.111.0` and correcting the model IDs (`claude-haiku-4-5-20251001`, `claude-sonnet-4-6`).
 
-**Prompt 3:** *(Sesión 10 — componente de email: Resend → SMTP)*
+**Prompt 3:** *(Session 10 — email component: Resend → SMTP)*
 
-> "el correo de recuperación nunca me llega" → "que otras librerías existen para enviar mail desde una cuenta configurada?" → "vamos por la opción A: aiosmtplib"
+> "the recovery email never arrives" → "what other libraries exist to send mail from a configured account?" → "let's go with option A: aiosmtplib"
 
-Resend sin dominio verificado solo entrega al dueño de la cuenta. Se **migró `NotificationService` de Resend a SMTP con `aiosmtplib`** (nativo async, multipart texto+HTML): nuevas vars `SMTP_*`, `resend==2.3.0` → `aiosmtplib==3.0.2`. Los sends nunca lanzan (anti-enumeración). Cambiar de proveedor es solo configuración.
+Resend without a verified domain only delivers to the account owner. `NotificationService` was **migrated from Resend to SMTP with `aiosmtplib`** (async-native, multipart text+HTML): new `SMTP_*` vars, `resend==2.3.0` → `aiosmtplib==3.0.2`. Sends never raise (anti-enumeration). Changing providers is just configuration.
 
-### **2.3. Descripción de alto nivel del proyecto y estructura de ficheros**
+### **2.3. High-level project description and file structure**
 
-**Prompt 1:** *(Sesión 2 — estructura documentada vía doc-generator)*
+**Prompt 1:** *(Session 2 — structure documented via doc-generator)*
 
-> "@ia-agents/agents/doc-generator.md genera la documentacion del proyecto"
+> "@ia-agents/agents/doc-generator.md generate the project documentation"
 
-La estructura de ficheros (monorepo frontend/backend, feature-based en el front, layered en el back) se generó como parte de las secciones 2 y 3 de `architecture.md`.
+The file structure (frontend/backend monorepo, feature-based on the front, layered on the back) was generated as part of sections 2 and 3 of `architecture.md`.
 
-**Prompt 2:** *(Sesión 3 — Expo + Tamagui desde el día 1)*
+**Prompt 2:** *(Session 3 — Expo + Tamagui from day 1)*
 
-> "11. Si la migración mobile está comprometida, usar Expo desde el día uno (Expo Router + Tamagui o React Native Web)."
+> "11. If the mobile migration is at risk, use Expo from day one (Expo Router + Tamagui or React Native Web)."
 
-Cambió la estructura de `frontend/` de "React SPA reescribible a React Native" a "Expo Router + Tamagui con build web vía React Native Web desde el primer componente". Las capas `services/` y `store/` quedan portables a móvil sin reescritura.
+Changed the structure of `frontend/` from "React SPA rewritable to React Native" to "Expo Router + Tamagui with a web build via React Native Web from the very first component". The `services/` and `store/` layers remain portable to mobile without a rewrite.
 
-**Prompt 3:** *(Sesión 4 — scaffolding del proyecto)*
+**Prompt 3:** *(Session 4 — project scaffolding)*
 
-> "procede con el scaffolding del proyecto basandote en lo que se encuentra en @docs/architecture.md"
+> "proceed with the project scaffolding based on what's in @docs/architecture.md"
 
-Generó 79 archivos que materializan la estructura documentada: raíz (`docker-compose.yml`, `.env.example`, CI), backend (FastAPI con `/auth` implementado, `deps.py` con `SET LOCAL app.clinic_id` para RLS, mixins SQLAlchemy, Alembic async, ARQ, `conftest.py`) y frontend (Expo Router + Tamagui, store Zustand, axios con refresh queue, guard de auth).
+Generated 79 files that materialize the documented structure: root (`docker-compose.yml`, `.env.example`, CI), backend (FastAPI with `/auth` implemented, `deps.py` with `SET LOCAL app.clinic_id` for RLS, SQLAlchemy mixins, async Alembic, ARQ, `conftest.py`) and frontend (Expo Router + Tamagui, Zustand store, axios with a refresh queue, auth guard).
 
-### **2.4. Infraestructura y despliegue**
+### **2.4. Infrastructure and deployment**
 
-**Prompt 1:** *(Sesión 3 — consolidación en Railway)*
+**Prompt 1:** *(Session 3 — consolidation on Railway)*
 
-> "Vercel + Railway → Railway solo"
+> "Vercel + Railway → Railway only"
 
-Reescritura de la sección de infraestructura: todos los servicios (frontend estático, backend, ARQ worker, cron, Postgres, Redis) viven en un único proyecto Railway. El reverse proxy interno elimina CORS frontend-backend; se removieron las referencias a Vercel y a Render como alternativas.
+Rewrite of the infrastructure section: all services (static frontend, backend, ARQ worker, cron, Postgres, Redis) live in a single Railway project. The internal reverse proxy eliminates frontend-backend CORS; references to Vercel and Render as alternatives were removed.
 
-**Prompt 2:** *(Sesión 24 — recordatorios: del plan a la decisión real)*
+**Prompt 2:** *(Session 24 — reminders: from the plan to the real decision)*
 
-> *(US-021, AskUserQuestion sobre el schedule del cron)* el usuario simplificó a **una corrida diaria que avisa los turnos de mañana** y **un solo recordatorio** (se descarta el de 48h)
+> *(US-021, AskUserQuestion about the cron schedule)* the user simplified to **a single daily run that notifies tomorrow's appointments** and **a single reminder** (the 48h one is dropped)
 
-El plan original (recordatorios 48h y 24h, cron cada 15 min) se simplificó a un cron diario `0 8 * * *` (`backend/railway.cron.json`) con `trigger_hours_before=24`. Idempotencia en dos capas: guard `has_sent` + índice UNIQUE parcial `(appointment_id, trigger_hours_before) WHERE status='sent'`. El cron corre sin JWT → bypassa RLS (`app_admin`). La hora se localiza a `clinics.timezone` (se agregó `tzdata` para resolver zonas IANA en Windows/contenedores).
+The original plan (48h and 24h reminders, cron every 15 min) was simplified to a daily cron `0 8 * * *` (`backend/railway.cron.json`) with `trigger_hours_before=24`. Idempotency in two layers: a `has_sent` guard + a partial UNIQUE index `(appointment_id, trigger_hours_before) WHERE status='sent'`. The cron runs without a JWT → bypasses RLS (`app_admin`). The time is localized to `clinics.timezone` (`tzdata` was added to resolve IANA zones on Windows/containers).
 
-**Prompt 3:** *(Sesión — estimación de billing)*
+**Prompt 3:** *(Session — billing estimate)*
 
-> "en funcion de las herramientas y tecnologias elegidas, realizame una estimacion de billing para el proyecto como un mvp funcional de pocos usuarios"
+> "based on the chosen tools and technologies, give me a billing estimate for the project as a functional MVP with few users"
 
-Produjo una tabla detallada por servicio. Total para un MVP de pocos usuarios: **~U$ 55–70/mes** en Railway-solo (la transcripción usa la capa gratuita de Groq; Claude con prompt caching es marginal a este volumen). Identificó que el cuello de botella económico no es la infraestructura sino el tiempo de los founders.
+Produced a detailed table per service. Total for a few-user MVP: **~US$ 55–70/month** on Railway-only (transcription uses Groq's free tier; Claude with prompt caching is marginal at this volume). It identified that the economic bottleneck is not the infrastructure but the founders' time.
 
-### **2.5. Seguridad**
+### **2.5. Security**
 
-**Prompt 1:** *(Sesión 3 — RLS como defensa en profundidad)*
+**Prompt 1:** *(Session 3 — RLS as defense in depth)*
 
-> "de los cambios sugeridos para estándares 2026... 8. Defensa en profundidad para multi-tenancy: PostgreSQL Row-Level Security (RLS) además del filtro en queries; tests de regresión que validen aislamiento entre clínicas."
+> "of the changes suggested for 2026 standards... 8. Defense in depth for multi-tenancy: PostgreSQL Row-Level Security (RLS) in addition to the query filter; regression tests that validate isolation between clinics."
 
-Incorporó RLS (setup `ENABLE/FORCE ROW LEVEL SECURITY`, policy por tabla, usuarios `app_runtime`/`app_admin`) + suite de aislamiento bloqueante en CI.
+Incorporated RLS (`ENABLE/FORCE ROW LEVEL SECURITY` setup, per-table policy, `app_runtime`/`app_admin` users) + a blocking isolation suite in CI.
 
-**Prompt 2:** *(Sesión 3 — entidades de auditoría append-only)*
+**Prompt 2:** *(Session 3 — append-only audit entities)*
 
-> "es buena idea/practica incorporar al modelo de datos una entidad que registre los logs/historial de las consultas, transacciones, etc a la DB?" → "si, aplicame los cambios"
+> "is it a good idea/practice to add to the data model an entity that records the logs/history of queries, transactions, etc. to the DB?" → "yes, apply the changes"
 
-Incorporó dos tablas append-only: `audit_log` (mutaciones con diff JSONB, auto-poblada vía SQLAlchemy `after_flush`) y `clinical_record_access_log` (lecturas de historias clínicas, Ley 25.326). Append-only enforced en motor (`REVOKE UPDATE, DELETE`).
+Incorporated two append-only tables: `audit_log` (mutations with JSONB diff, auto-populated via SQLAlchemy `after_flush`) and `clinical_record_access_log` (reads of clinical records, Law 25.326). Append-only enforced at the engine level (`REVOKE UPDATE, DELETE`).
 
-**Prompt 3:** *(Sesión 9a — bug raíz de RLS al ejercerlo contra Postgres real)*
+**Prompt 3:** *(Session 9a — root RLS bug when exercising it against real Postgres)*
 
-> "cuando se quiere crear un nuevo usuario... al darle al boton crear muestra un mensaje de error inesperado"
+> "when trying to create a new user... clicking the create button shows an unexpected error message"
 
-`get_current_user` usaba `text("SET LOCAL app.clinic_id = :cid")` y PostgreSQL no acepta parámetros vinculados en `SET` → 500 en toda request autenticada (no detectado por los tests, que mockean sobre SQLite). **Fix:** `SELECT set_config('app.clinic_id', :cid, true)`. US-003 fue la primera feature que ejerció ese camino contra Postgres.
+`get_current_user` used `text("SET LOCAL app.clinic_id = :cid")` and PostgreSQL does not accept bound parameters in `SET` → 500 on every authenticated request (not caught by the tests, which mock over SQLite). **Fix:** `SELECT set_config('app.clinic_id', :cid, true)`. US-003 was the first feature that exercised that path against Postgres.
 
 ### **2.6. Tests**
 
-**Prompt 1:** *(Sesión 3 — Playwright + syrupy)*
+**Prompt 1:** *(Session 3 — Playwright + syrupy)*
 
-> "10. Testing E2E mínimo del flujo IA con Playwright; snapshot tests del prompt enviado a Claude."
+> "10. Minimal E2E testing of the AI flow with Playwright; snapshot tests of the prompt sent to Claude."
 
-Stack de testing base: pytest + pytest-asyncio (engine aiosqlite, rollback por test) + **Playwright** (E2E del flujo IA) + **syrupy** (snapshot del prompt + schema enviado a Claude, bloquea merges).
+Base testing stack: pytest + pytest-asyncio (aiosqlite engine, rollback per test) + **Playwright** (E2E of the AI flow) + **syrupy** (snapshot of the prompt + schema sent to Claude, blocks merges).
 
-**Prompt 2:** *(Implementación — TDD por capa en `/implement-us`)*
+**Prompt 2:** *(Implementation — TDD by layer in `/implement-us`)*
 
-> El flujo `/implement-us` despacha al agente `tdd-specialist` tras cada capa (DB → BE → FE), ejecutando RED→GREEN→REFACTOR.
+> The `/implement-us` flow dispatches the `tdd-specialist` agent after each layer (DB → BE → FE), running RED→GREEN→REFACTOR.
 
-En implementación se sumó **Jest + React Native Testing Library** para el frontend (mock de Tamagui/Expo Router/Zustand/TanStack Query). Al cierre del MVP la suite backend supera los 570 tests y la de frontend los 400.
+In implementation, **Jest + React Native Testing Library** was added for the frontend (mocking Tamagui/Expo Router/Zustand/TanStack Query). At the close of the MVP the backend suite exceeds 570 tests and the frontend one exceeds 400.
 
-**Prompt 3:** *(Implementación — aislamiento multi-tenant + append-only bloqueante)*
+**Prompt 3:** *(Implementation — multi-tenant isolation + blocking append-only)*
 
-> Suite custom de pytest que verifica el aislamiento entre clínicas y que `UPDATE`/`DELETE` sobre `audit_log` desde `app_runtime` falle con `permission denied`.
+> Custom pytest suite that verifies isolation between clinics and that `UPDATE`/`DELETE` on `audit_log` from `app_runtime` fails with `permission denied`.
 
-Es un test **bloqueante en CI**: materializa la garantía de RLS (una clínica no ve filas de otra) y la inmutabilidad append-only directamente contra el motor Postgres, no solo en la capa ORM.
-
----
-
-## 3. Modelo de Datos
-
-**Prompt 1:** *(Sesión 2 — generación inicial del ERD)*
-
-> "@ia-agents/agents/doc-generator.md genera la documentacion del proyecto"
-
-Generó el ERD inicial en `data-model.md` con las entidades principales (clinics, users, clients, pets, appointments, clinical_records, clinical_records_ai, vaccinations + tablas de auditoría).
-
-**Prompt 2:** *(Sesión — justificación de separar users vs clients)*
-
-> "se indica la creacion de dos entidades, 'usuarios' y 'clientes'... Que justificacion encontras para tener esas 2 entidades y no unificarlas?"
-
-Justificación: distintos FKs, distintos ciclos de vida, distintos modelos de auth (JWT staff vs JWT portal en Fase 1.5), RLS más simple con tablas separadas.
-
-**Prompt 3:** *(Sesiones 15, 18, 19, 21 — materialización incremental en migraciones)*
-
-> *(US-009)* `/implement-us 264` — migración `0005` crea `clinical_records` + `audit_log` + listener. *(US-023)* `0006` crea `vaccinations`. *(US-019)* `0007` agrega `cancellation_reason`. *(US-011)* `0008` crea `clinical_record_access_log`. *(US-013)* `0011` crea `clinical_records_ai` append-only.
-
-El modelo se materializó incrementalmente en migraciones Alembic `0001`–`0011`, cada tabla dentro del ticket de la US que la necesita primero. Hallazgo recurrente: el `head` de Alembic debía confirmarse con `alembic heads` antes de encadenar `down_revision` (varias US en paralelo colgaban de la misma migración).
+It is a **CI-blocking** test: it materializes the RLS guarantee (one clinic does not see another's rows) and the append-only immutability directly against the Postgres engine, not just at the ORM layer.
 
 ---
 
-## 4. Especificación de la API
+## 3. Data Model
 
-**Prompt 1:** *(Sesión 3 — endpoint `/ai/extract-record` con alcance acotado)*
+**Prompt 1:** *(Session 2 — initial ERD generation)*
 
-> "la idea que tenemos es utilizar un modelo de IA para que, en funcion de una historia clinica con un formato y estructura definidos, se complete la misma con la informacion transcrita... necesito que modifiques los archivos del proyecto para reflejar esta decision."
+> "@ia-agents/agents/doc-generator.md generate the project documentation"
 
-El endpoint pasó de `/ai/generate-record` (genera todo) a un contrato de estructuración de los campos extraíbles.
+Generated the initial ERD in `data-model.md` with the main entities (clinics, users, clients, pets, appointments, clinical_records, clinical_records_ai, vaccinations + audit tables).
 
-**Prompt 2:** *(Sesión 27 — implementación del flujo IA real, US-013)*
+**Prompt 2:** *(Session — justification for separating users vs clients)*
+
+> "the creation of two entities is indicated, 'users' and 'clients'... What justification do you find for having those 2 entities and not unifying them?"
+
+Justification: different FKs, different lifecycles, different auth models (JWT staff vs JWT portal in Phase 1.5), simpler RLS with separate tables.
+
+**Prompt 3:** *(Sessions 15, 18, 19, 21 — incremental materialization in migrations)*
+
+> *(US-009)* `/implement-us 264` — migration `0005` creates `clinical_records` + `audit_log` + listener. *(US-023)* `0006` creates `vaccinations`. *(US-019)* `0007` adds `cancellation_reason`. *(US-011)* `0008` creates `clinical_record_access_log`. *(US-013)* `0011` creates `clinical_records_ai` append-only.
+
+The model was materialized incrementally in Alembic migrations `0001`–`0011`, each table within the ticket of the US that needs it first. Recurring finding: the Alembic `head` had to be confirmed with `alembic heads` before chaining `down_revision` (several parallel USs hung off the same migration).
+
+---
+
+## 4. API Specification
+
+**Prompt 1:** *(Session 3 — `/ai/extract-record` endpoint with narrowed scope)*
+
+> "the idea we have is to use an AI model so that, based on a clinical record with a defined format and structure, it gets filled in with the transcribed information... I need you to modify the project files to reflect this decision."
+
+The endpoint went from `/ai/generate-record` (generates everything) to a contract for structuring the extractable fields.
+
+**Prompt 2:** *(Session 27 — implementation of the real AI flow, US-013)*
 
 > `/implement-us 268`
 
-Materializó el flujo IA: `POST /ai/transcribe-voice` (202 + task_id), `GET /ai/tasks/{task_id}` (polling), y el pipeline ARQ **Groq Whisper (`whisper-large-v3`) → Claude Haiku cleanup → Claude Sonnet tool use**. Decisiones reales: Groq Whisper vía SDK de OpenAI con `base_url` override; el worker crea su propia sesión con `set_config` para RLS; subida del SDK `anthropic` a `0.111.0` y corrección de model IDs (`claude-haiku-4-5-20251001`, `claude-sonnet-4-6`).
+Materialized the AI flow: `POST /ai/transcribe-voice` (202 + task_id), `GET /ai/tasks/{task_id}` (polling), and the ARQ pipeline **Groq Whisper (`whisper-large-v3`) → Claude Haiku cleanup → Claude Sonnet tool use**. Real decisions: Groq Whisper via the OpenAI SDK with a `base_url` override; the worker creates its own session with `set_config` for RLS; bumping the `anthropic` SDK to `0.111.0` and correcting the model IDs (`claude-haiku-4-5-20251001`, `claude-sonnet-4-6`).
 
-**Prompt 3:** *(Sesión 28 — segundo endpoint del flujo IA, US-014)*
+**Prompt 3:** *(Session 28 — second endpoint of the AI flow, US-014)*
 
 > `/implement-us 269`
 
-`POST /ai/transcribe-upload` para subir un archivo de audio externo: valida formato (MIME con fallback a extensión) y tamaño (413 para > 20 MB), reutiliza el mismo pipeline ARQ con `input_type="upload"`. Reutilización masiva de US-013 (tabla, schema y polling sin cambios).
+`POST /ai/transcribe-upload` to upload an external audio file: validates format (MIME with fallback to extension) and size (413 for > 20 MB), reuses the same ARQ pipeline with `input_type="upload"`. Massive reuse of US-013 (table, schema and polling unchanged).
 
-> **Otros endpoints implementados** a lo largo del MVP: `/auth/*` (register/login/refresh/logout/forgot-password/reset-password), `/users`, `/clients`, `/pets` (+ perfil agregado), `/search`, `/appointments` (crear/listar/reprogramar/cancelar/marcar-atendido/notifications), `/clinical-records` (crear/ver/editar/borrar/by-appointment/attachments), `/pets/{id}/vaccinations`, e internos (`/internal/notifications/send-reminders`).
-
----
-
-## 5. Historias de Usuario
-
-**Prompt 1:** *(Sesión 2 — generación inicial)*
-
-> "@ia-agents/agents/doc-generator.md genera la documentacion del proyecto"
-
-Generó 32 historias de usuario distribuidas en módulos.
-
-**Prompt 2:** *(Sesión 3 — ajuste de US-013/014/015 por scope IA)*
-
-> "no se busca por ahora que el modelo genere diagnosticos ni sugerencias terapeuticas. reescribí las historias de usuario del módulo de historia clínica asistida por IA para reflejar este alcance acotado."
-
-Las historias del Módulo 4 se reescribieron: "que la app complete los campos predefinidos a partir de lo dictado".
-
-**Prompt 3:** *(Sesión 22 — US emergente durante la implementación: nace US-020b)*
-
-> "estaria bien que si ya tiene una consulta cargada, al clickear te la muestre y puedas modificarla, no seguir cargando otras" → "Si, crea la US-020-b asi se sabe que continua a esta"
-
-Probando US-020 (marcar atendido) se detectó que se podían cargar historias duplicadas por turno y no había forma de ver la ya cargada. El `user-story-agent` redactó **US-020b** (issues #402/#403/#404): `GET /clinical-records/by-appointment/{id}` + `PATCH` de edición auditada + guard 409 anti-duplicado, y modo edición en el modal. Ejemplo de cómo el testing manual de una US generó la siguiente.
+> **Other endpoints implemented** throughout the MVP: `/auth/*` (register/login/refresh/logout/forgot-password/reset-password), `/users`, `/clients`, `/pets` (+ aggregated profile), `/search`, `/appointments` (create/list/reschedule/cancel/mark-attended/notifications), `/clinical-records` (create/view/edit/delete/by-appointment/attachments), `/pets/{id}/vaccinations`, and internal ones (`/internal/notifications/send-reminders`).
 
 ---
 
-## 6. Tickets de Trabajo
+## 5. User Stories
 
-**Prompt 1:** *(Sesión de generación — estrategia modular)*
+**Prompt 1:** *(Session 2 — initial generation)*
 
-> "genera los tickets de trabajo para cada historia de usuario en @docs/user-stories.md, aplicando el formato BDD con criterios Dado que / Cuando / Entonces, evaluación INVEST y estimación de talla S/M/L"
+> "@ia-agents/agents/doc-generator.md generate the project documentation"
 
-El `user-story-agent` procesó los módulos uno por uno con ediciones quirúrgicas (límite de tokens de output). Resultado inicial: 82 tickets (41 BE + 41 FE).
+Generated 32 user stories distributed across modules.
 
-**Prompt 2:** *(Sesión 4 — modelo de 5 capas)*
+**Prompt 2:** *(Session 3 — adjustment of US-013/014/015 by AI scope)*
 
-> "@.claude/agents/user-story-agent.md indica al agente que se debe generar user story y tickets de todo el espectro de desarrollo, no solo backend y frontend"
+> "for now we don't want the model to generate diagnoses or therapeutic suggestions. rewrite the user stories of the AI-assisted clinical record module to reflect this narrowed scope."
 
-Se definió el modelo de 5 capas (`-BE`, `-FE`, `-DB`, `-INFRA`, `-AI`), creando ticket de capa separado solo cuando ese trabajo puede asignarse a otra persona, tiene criterios propios y se testea de forma autónoma. Aplicado retroactivamente: total **91 tickets**, importados a GitHub Issues con `scripts/import_to_github.py` (labels por capa).
+The Module 4 stories were rewritten: "that the app fills in the predefined fields from what is dictated".
 
-**Prompt 3:** *(Sesión 7 — planificación por US con el agente `planning-specialist`)*
+**Prompt 3:** *(Session 22 — a US emerging during implementation: US-020b is born)*
 
-> "Bien, faltaria que el plan de implementacion sea un poco mas detallado. Que se podria agregar?" + "porque se crea un agente y no una skill?"
+> "it would be good that if it already has a record loaded, clicking it shows it and you can modify it, not keep loading others" → "Yes, create US-020-b so it's known it continues this one"
 
-Se creó el agente `planning-specialist`, invocado en el Paso 0 de `/implement-us`: lee el issue padre + cada ticket con sus criterios BDD + el codebase, y genera `docs/changelog/US-XXX.md` con seis componentes por ticket (criterios de done, archivos esperados, contrato de interfaz, riesgos, scope explícito y dependencias). El aislamiento de contexto del agente evita inflar el del orquestador. Cada US implementada (US-001 a US-014, US-017 a US-023, US-DASH) tiene su `docs/changelog/US-XXX.md`.
+While testing US-020 (mark attended) it was found that duplicate records could be loaded per appointment and there was no way to see the already loaded one. The `user-story-agent` drafted **US-020b** (issues #402/#403/#404): `GET /clinical-records/by-appointment/{id}` + an audited edit `PATCH` + a 409 anti-duplicate guard, and edit mode in the modal. An example of how manual testing of one US generated the next.
+
+---
+
+## 6. Work Tickets
+
+**Prompt 1:** *(Generation session — modular strategy)*
+
+> "generate the work tickets for each user story in @docs/user-stories.md, applying the BDD format with Given / When / Then criteria, INVEST evaluation and S/M/L size estimation"
+
+The `user-story-agent` processed the modules one by one with surgical edits (output token limit). Initial result: 82 tickets (41 BE + 41 FE).
+
+**Prompt 2:** *(Session 4 — 5-layer model)*
+
+> "@.claude/agents/user-story-agent.md tell the agent that user stories and tickets must be generated across the whole development spectrum, not just backend and frontend"
+
+The 5-layer model was defined (`-BE`, `-FE`, `-DB`, `-INFRA`, `-AI`), creating a separate layer ticket only when that work can be assigned to another person, has its own criteria and is tested autonomously. Applied retroactively: total **91 tickets**, imported to GitHub Issues with `scripts/import_to_github.py` (labels per layer).
+
+**Prompt 3:** *(Session 7 — per-US planning with the `planning-specialist` agent)*
+
+> "Good, what's left is for the implementation plan to be a bit more detailed. What could be added?" + "why is an agent created and not a skill?"
+
+The `planning-specialist` agent was created, invoked in Step 0 of `/implement-us`: it reads the parent issue + each ticket with its BDD criteria + the codebase, and generates `docs/changelog/US-XXX.md` with six components per ticket (done criteria, expected files, interface contract, risks, explicit scope and dependencies). The agent's context isolation avoids bloating the orchestrator's. Each implemented US (US-001 to US-014, US-017 to US-023, US-DASH) has its `docs/changelog/US-XXX.md`.
 
 ---
 
 ## 7. Pull Requests
 
-**Prompt 1:** *(Sesión 6 — definición del flujo git/board)*
+**Prompt 1:** *(Session 6 — definition of the git/board flow)*
 
-> "como seria el flujo de manejo de git?" + "las issues de github issues y del project como las manejas?"
+> "what would the git management flow look like?" + "how do you manage the GitHub issues and the project ones?"
 
-Se definió el flujo: rama `feat/us-XXX` desde `dev` actualizado; un commit por ticket (conventional commits); `gh pr create --base dev` con `Closes #N`; integración con GitHub Projects v2 (Todo → In Progress al iniciar → In Review al crear el PR → Done **manual** tras el merge, porque el PR apunta a `dev`, no a `main`).
+The flow was defined: `feat/us-XXX` branch from an updated `dev`; one commit per ticket (conventional commits); `gh pr create --base dev` with `Closes #N`; integration with GitHub Projects v2 (Todo → In Progress on start → In Review on PR creation → Done **manually** after the merge, because the PR targets `dev`, not `main`).
 
-**Prompt 2:** *(Sesión 23 — cierre y limpieza de una US)*
+**Prompt 2:** *(Session 23 — closing and cleanup of a US)*
 
-> "si, arranca. Ya hice el pr y me movi a dev haciendo pull"
+> "yes, go ahead. I already made the PR and moved to dev with a pull"
 
-Patrón de cierre real por US: mergear el PR a `dev`, mover los issues (padre + tickets) a Done manualmente, limpiar la rama (`git push origin --delete`, `git fetch --prune`), y actualizar `prompts.md`/`README.md`/`CLAUDE.md` cuando la feature cambia el comportamiento documentado.
+Real per-US closing pattern: merge the PR to `dev`, move the issues (parent + tickets) to Done manually, clean up the branch (`git push origin --delete`, `git fetch --prune`), and update `prompts.md`/`README.md`/`CLAUDE.md` when the feature changes documented behavior.
 
-**Prompt 3:** *(Sesiones 9–28 — síntesis del resultado)*
+**Prompt 3:** *(Sessions 9–28 — synthesis of the result)*
 
-> Convención sostenida durante toda la implementación: un PR por User Story sobre `dev`, con changelog por ticket y testing manual contra Postgres real antes de cerrar.
+> Convention sustained throughout the implementation: one PR per User Story onto `dev`, with a changelog per ticket and manual testing against real Postgres before closing.
 
-Se completaron **24 PRs mergeados a `dev`** (`#388`–`#418`): US-001 a US-014, US-017 a US-023, US-DASH y un fix de UX de adjuntos. Cada PR cierra su issue padre y sus tickets, con la suite de tests (backend > 570, frontend > 400) y, para los flujos críticos, specs de Playwright. Los PRs a `main` quedan para el cierre de Fase 1.
+**24 PRs merged to `dev`** were completed (`#388`–`#418`): US-001 to US-014, US-017 to US-023, US-DASH and an attachments UX fix. Each PR closes its parent issue and its tickets, with the test suite (backend > 570, frontend > 400) and, for the critical flows, Playwright specs. The PRs to `main` are reserved for the close of Phase 1.

--- a/prompts.md
+++ b/prompts.md
@@ -1,22 +1,8 @@
-**Estructura de sesiones:** El proyecto se desarrolló en 3 sesiones de trabajo (20+ prompts). La Sesión 1 cubrió la definición inicial del producto con el agente Analyst de BMAD. La Sesión 2 generó la documentación técnica completa via el agente `doc-generator`. La Sesión 3 fue una revisión arquitectónica crítica que derivó en decisiones de scope y adopción de estándares 2026; los prompts de esa sesión son los más representativos y los que se detallan con mayor profundidad en este documento.
+**Estructura de sesiones:** El proyecto atravesó dos grandes etapas. **Etapa de documentación (Sesiones 1–3):** definición del producto con el agente Analyst de BMAD, generación de la documentación técnica completa vía el agente `doc-generator`, y una revisión arquitectónica crítica que fijó el alcance del MVP y la adopción de estándares 2026. **Etapa de implementación (Sesiones 4–28):** generación de tickets por capa, scaffolding, configuración del flujo `/implement-us` y desarrollo iterativo de las User Stories (US-001 a US-014, US-017 a US-023 y US-DASH), cada una con su PR a `dev`. Este documento selecciona, por cada sección de la entrega, los prompts **más relevantes** de ambas etapas. El log cronológico íntegro vive en [docs/prompts/prompts.md](../docs/prompts/prompts.md).
 
-> **Contexto de la Sesión 3 — lista de recomendaciones referenciada en este documento:** Al inicio de esa sesión el asistente entregó una revisión crítica del stack organizada en dos bloques numerados. Los "puntos" mencionados en los prompts de las secciones 2.x corresponden a la siguiente lista:
->
-> *Cambios por alcance del MVP (2 founders, MVP):*
-> 1. Celery + Redis es overkill → reemplazar por ARQ (async-nativo, mismo Redis) + cron de Railway para jobs programados
-> 2. Offline-first es el mayor inflador de alcance del MVP → diferir Service Workers + IndexedDB a Fase 2; comprometer sólo cache read-only en Fase 1
-> 3. Dos clouds (Vercel + Railway) duplican la operación → consolidar todo en un único proyecto Railway
-> 4. JWT + refresh tokens en Redis para staff es complejidad temprana → evaluar cookies httpOnly opacas o auth managed (Clerk / WorkOS / Supabase Auth)
-> 5. No construir el calendario ni la data grid a mano → Schedule-X o FullCalendar para agenda; TanStack Table para grids
->
-> *Cambios por estándares 2026:*
-> 6. Prompt caching de Anthropic desde el día uno (~80% de ahorro en tokens cacheados)
-> 7. Output estructurado con Pydantic + tool use en lugar de JSON suelto
-> 8. Defensa en profundidad para multi-tenancy: PostgreSQL Row-Level Security (RLS) + suite de tests de aislamiento bloqueante en CI
-> 9. Observabilidad: Sentry + Pydantic Logfire / OpenTelemetry + PostHog
-> 10. Testing E2E mínimo del flujo IA con Playwright + snapshot tests del prompt enviado a Claude (syrupy)
-> 11. Si la migración mobile está comprometida, usar Expo desde el día uno (Expo Router + Tamagui o React Native Web)
-> 12. Selección de modelo por tarea: `claude-haiku-4-5` para inputs cortos/limpieza; `claude-sonnet-4-6` para inputs largos o multimodales
+> **Flujo de desarrollo (Sesiones 6–8).** A partir de la Sesión 6 se construyó el comando `/implement-us <issue>`, que orquesta el ciclo completo de una US: el agente `planning-specialist` genera `docs/changelog/US-XXX.md` (criterios de done, archivos esperados, contrato de interfaz, riesgos, scope y dependencias por ticket); luego se despachan agentes en orden **INFRA → DB → BE → FE**, con `tdd-specialist` tras cada uno y consulta a Stitch MCP antes del FE. Cada ticket genera un commit (`feat(db|be|fe):`) y la US un PR a `dev`. El board de GitHub Projects recorre Todo → In Progress → In Review → Done.
+
+> **Decisiones de implementación que divergieron del plan original** (documentadas en los prompts de abajo): email **Resend → SMTP `aiosmtplib`** (US-004); transcripción **OpenAI `whisper-1` → Groq `whisper-large-v3`** (US-013); recordatorios **48h+24h cada 15 min → un único cron diario a las 08:00 para los turnos de mañana** (US-021); alcance IA **ampliado** para extraer diagnóstico/tratamiento *cuando el veterinario los dicta explícitamente* —sin inventarlos nunca— (US-013).
 
 ## Índice
 
@@ -36,25 +22,19 @@
 
 > "Quiero construir @docs/idea-inicial.md — Actuar como el agente Analyst de BMAD"
 
-Disparó el cuestionario inicial del Analyst (10 preguntas sobre piloto, modelo SaaS, roles, notificaciones, exportación, voz, offline, validación IA, stack). Las respuestas al cuestionario fijaron las decisiones fundacionales del producto: SaaS multi-clínica desde el inicio, 3 roles staff + 1 portal cliente, email primero / WhatsApp después, validación IA con edición opcional, stack React + FastAPI + Postgres + Whisper + Claude, soporte offline requerido (luego diferido a Fase 2).
+Disparó el cuestionario inicial del Analyst (10 preguntas sobre piloto, modelo SaaS, roles, notificaciones, exportación, voz, offline, validación IA, stack). Las respuestas fijaron las decisiones fundacionales: SaaS multi-clínica, 3 roles staff + portal cliente, email primero / WhatsApp después, validación IA con edición opcional, stack React + FastAPI + Postgres + Whisper + Claude.
 
 **Prompt 2:** *(Sesión 3 — scope IA acotado al MVP)*
 
-> "dadas las sugerencias del stack tecnologico revisado y los cambios propuestos, para los puntos:
-> 6. Prompt caching de Anthropic desde el día uno (cuts ~80% de tokens cacheados).
-> 7. Output estructurado con Pydantic + tool use en lugar de JSON suelto.
->
-> la idea que tenemos es utilizar un modelo de IA para en funcion de una historia clinica con un formato y estructura definidos, se complete la misma con la informacion transcrita de el audio/imagen/texto que carge el especialista. no se busca por ahora que el modelo genere diagnosticos o sugerencias para incluir en la historia clinica. se podria dejar para una etapa posterior. necesito que modifiques los archivos del proyecto para reflejar esta decision."
+> "la idea que tenemos es utilizar un modelo de IA para en funcion de una historia clinica con un formato y estructura definidos, se complete la misma con la informacion transcrita de el audio/imagen/texto que carge el especialista. no se busca por ahora que el modelo genere diagnosticos o sugerencias para incluir en la historia clinica."
 
-Cambio de alcance fundamental para el value proposition. La IA pasa de "genera la historia clínica" a "estructura los campos predefinidos". El cambio se propagó a 8 archivos: features, RFs, RNFs, user stories, schema Pydantic `ClinicalRecordExtraction` (sin `diagnosis` ni `treatment_suggestion`), Use Case 1, riesgos. Define la promesa real del MVP frente a las clínicas piloto.
+Cambio de alcance fundamental: la IA pasa de "genera la historia clínica" a "estructura los campos predefinidos". Se propagó a 8 archivos (features, RFs, RNFs, user stories, schema `ClinicalRecordExtraction`, Use Case 1, riesgos).
 
-**Prompt 3:** *(Sesión 3 — diferimiento de offline y Portal del Cliente)*
+**Prompt 3:** *(Sesión 27 — ampliación del alcance IA al implementarlo)*
 
-> "ejecutame paso a paso los siguientes puntos:
-> - del punto 2 de los cambios sugeridos por alcance ('Offline-first es el mayor inflador de alcance del MVP — Service Workers + IndexedDB + cola de mutaciones + last-write-wins es un proyecto en sí mismo'), la idea es posponer la funcionalidad o soporte offline para una fase posterior del proyecto, por lo tanto modifica todos los archivos del proyecto, eliminando toda referencia a dicha funcionalidad y componentes o estructuras que la conformen.
-> - el entidad de cliente, junto con el portal al que accede el mismo, tambien lo pensamos para una fase 1.5 del proyecto. contempla esta decision modificando los archivos del proyecto donde se mencione dicha funcionalidad."
+> "probe el flujo... me transcribio los datos del audio, pero no me seteo todos los campos de la estructura" → "si" (confirma ajustar el prompt para extraer diagnosis/treatment cuando el vet los dicta)
 
-Recorte de alcance del MVP. Soporte offline → Fase 2. Portal del Cliente → Fase 1.5. El diseño se mantuvo documentado en todos los archivos pero marcado claramente como diferido, para reincorporarse sin reescritura cuando llegue su iteración.
+Al implementar US-013 se detectó que el prompt bloqueaba `diagnosis`/`treatment` aunque el vet los dictara. Se ajustó: el system prompt ahora extrae diagnóstico/tratamiento **si el vet los dicta explícitamente**, distingue `referred_medication` (lo que el dueño ya dio) de `treatment` (lo que indica el vet) y **nunca inventa**; el schema cambió esos campos de `None` fijo a `Optional[str]`. Matiz clave del MVP: la IA estructura lo dictado, no genera diagnósticos propios.
 
 ---
 
@@ -62,60 +42,63 @@ Recorte de alcance del MVP. Soporte offline → Fase 2. Portal del Cliente → F
 
 ### **2.1. Diagrama de arquitectura:**
 
-**Prompt 1:** *(Sesión 2 — generación inicial via doc-generator)*
+**Prompt 1:** *(Sesión 2 — generación inicial vía doc-generator)*
 
 > "@ia-agents/agents/doc-generator.md genera la documentacion del proyecto"
 
-Disparó el agente `doc-generator` (rol Senior Product Manager). Produjo el PRD completo con sección 11 (System Design) + sección 12 (C4: Context, Container, Component) usando 9 diagramas Mermaid.
+Disparó el agente `doc-generator` (rol Senior Product Manager). Produjo el PRD completo con la sección 11 (High-Level System Design) + sección 12 (C4: Context, Container, Component) usando diagramas Mermaid, base del *Figure 1* de arquitectura.
 
-**Prompt 2:** *(Sesión 3 — corrección de superposiciones en C4)*
-
-> "los otros 3 diagramas c4, no se visualizan correctamente, tienen superpociciones en algunos de sus componentes"
-
-Diagnóstico: la sintaxis nativa `C4Context` / `C4Container` / `C4Component` de Mermaid tiene auto-layout inmaduro que produce superposiciones. Se reescribieron los 3 diagramas usando `flowchart` + `subgraph` + `classDef` con la paleta oficial de C4 (navy person, azul system, azul claro component, gris ext, cilindro dbms). Se actualizó `ia-agents/rules/diagram-conventions.md` para que futuras generaciones eviten el problema desde el principio.
-
-**Prompt 3:** *(Sesión 3 — Code View C4 que faltaba)*
-
-> "en la generacion de documentacion, puntualmente del prd, en la seccion de diagramas C4 falto generar el diagrama 'Code'. genera el diagrama faltante"
-
-Se agregó *Figure 10* (`classDiagram` Mermaid) zoomeando el AI Orchestrator: jerarquía `AIProvider` (strategy pattern), `WhisperTranscriber`, `ContextBuilder`, `ModelSelector`, `AIService`, `ClinicalRecordExtraction` (Pydantic), `AuditLogger` y modelos SQLAlchemy.
-
-### **2.2. Descripción de componentes principales:**
-
-**Prompt 1:** *(Sesión 3 — revisión inicial del stack)*
+**Prompt 2:** *(Sesión 3 — revisión crítica del stack)*
 
 > "a partir de @docs/ que opinas de la arquitectura y stack elegidos para desarrollar este sistema, que cambiarias en funcion del alcance del proyecto y de los estandares actuales?"
 
-Revisión crítica del stack en tres bloques (aciertos / cambios por alcance / estándares 2026). Identificó: Celery + Redis es overkill para 2 founders → ARQ + cron Railway; Vercel + Railway → Railway-solo; construir agenda/grids → Schedule-X + TanStack Table.
+Revisión en tres bloques (aciertos / cambios por alcance / estándares 2026). Identificó: Celery + Redis es overkill → ARQ + cron Railway; Vercel + Railway → Railway-solo; construir agenda/grids a mano → Schedule-X + TanStack Table; prompt caching y RLS desde el día uno.
 
-**Prompt 2:** *(Sesión 3 — profundización de cada herramienta)*
+**Prompt 3:** *(Sesión 3 — aplicación de los cambios de simplificación)*
+
+> "de los cambios de alcance sugeridos: Celery → ARQ + cron Railway; Vercel + Railway → Railway solo; Construir agenda/grids vs librerías; no apliques el cambio de no utilizar jwt + redis"
+
+Propagó las tres decisiones a CLAUDE.md, README.md, architecture.md, prd.md, redibujando el diagrama de arquitectura general. Mantuvo JWT + Redis.
+
+### **2.2. Descripción de componentes principales:**
+
+**Prompt 1:** *(Sesión 3 — profundización de cada herramienta)*
 
 > "genera un archivo info.md dentro de @docs/ que explique y profundice en cada una de las herramientas de la primera seccion de la respuesta anterior"
 
-Creó `docs/info.md` con 4 secciones (Backend, Frontend, patrones de datos, patrones de IA) explicando cada herramienta: qué es, por qué es la elección correcta **para este proyecto**, ejemplo de código aplicado al dominio veterinario, buenas prácticas, riesgos.
+Creó `docs/info.md` con 4 secciones (Backend, Frontend, patrones de datos, patrones de IA) explicando cada componente: qué es, por qué es la elección correcta **para este proyecto**, ejemplo de código aplicado al dominio veterinario, buenas prácticas y riesgos.
 
-**Prompt 3:** *(Sesión 3 — aplicación de cambios al stack)*
+**Prompt 2:** *(Sesión 27 — materialización del componente de IA, US-013)*
 
-> "de los cambios de alcance sugeridos en la sesión (puntos 1, 3 y 5), modifica los archivos del proyecto para considerar los cambios: Celery → ARQ + cron Railway; Vercel + Railway → Railway solo; Construir agenda/grids vs librerías; no apliques el cambio de no utilizar jwt + redis"
+> `/implement-us 268`
 
-Propagó las tres decisiones de simplificación a CLAUDE.md, README.md, architecture.md, prd.md, entrega1/readme.md. Mantuvo JWT + Redis como pidió el usuario.
+Materializó el componente diferenciador: el pipeline ARQ **Groq Whisper (`whisper-large-v3`) → Claude Haiku cleanup → Claude Sonnet tool use**. Decisiones reales de componente: Groq Whisper vía SDK de OpenAI con `base_url` override; el worker crea su propia sesión con `set_config` para RLS; subida del SDK `anthropic` a `0.111.0` y corrección de model IDs (`claude-haiku-4-5-20251001`, `claude-sonnet-4-6`).
+
+**Prompt 3:** *(Sesión 10 — componente de email: Resend → SMTP)*
+
+> "el correo de recuperación nunca me llega" → "que otras librerías existen para enviar mail desde una cuenta configurada?" → "vamos por la opción A: aiosmtplib"
+
+Resend sin dominio verificado solo entrega al dueño de la cuenta. Se **migró `NotificationService` de Resend a SMTP con `aiosmtplib`** (nativo async, multipart texto+HTML): nuevas vars `SMTP_*`, `resend==2.3.0` → `aiosmtplib==3.0.2`. Los sends nunca lanzan (anti-enumeración). Cambiar de proveedor es solo configuración.
 
 ### **2.3. Descripción de alto nivel del proyecto y estructura de ficheros**
 
-**Prompt 1:** *(Sesión 2 — scaffolding documentado)*
+**Prompt 1:** *(Sesión 2 — estructura documentada vía doc-generator)*
 
 > "@ia-agents/agents/doc-generator.md genera la documentacion del proyecto"
 
-(Mismo prompt que 2.1 — la estructura de ficheros se generó como parte de architecture.md sección 2 y 3.)
+La estructura de ficheros (monorepo frontend/backend, feature-based en el front, layered en el back) se generó como parte de las secciones 2 y 3 de `architecture.md`.
 
 **Prompt 2:** *(Sesión 3 — Expo + Tamagui desde el día 1)*
 
-> "de los cambios sugeridos para estándares 2026, los siguientes puntos los vamos a adoptar, modifica todos los archivos del proyecto para incorporar dichas sugerencias:
-> 8. Defensa en profundidad para multi-tenancy: PostgreSQL Row-Level Security (RLS) además del filtro en queries; tests de regresión que validen aislamiento entre clínicas/clientes.
-> 10. Testing E2E mínimo del flujo IA con Playwright; snapshot tests del prompt enviado a Claude.
-> 11. Si la migración mobile está comprometida, usar Expo desde el día uno (Expo Router + Tamagui o React Native Web)."
+> "11. Si la migración mobile está comprometida, usar Expo desde el día uno (Expo Router + Tamagui o React Native Web)."
 
-Cambió la estructura de `frontend/` de "React SPA reescribible a React Native" a "Expo Router + Tamagui con build web vía React Native Web desde el primer componente". Capas `services/` y `store/` portables sin reescritura.
+Cambió la estructura de `frontend/` de "React SPA reescribible a React Native" a "Expo Router + Tamagui con build web vía React Native Web desde el primer componente". Las capas `services/` y `store/` quedan portables a móvil sin reescritura.
+
+**Prompt 3:** *(Sesión 4 — scaffolding del proyecto)*
+
+> "procede con el scaffolding del proyecto basandote en lo que se encuentra en @docs/architecture.md"
+
+Generó 79 archivos que materializan la estructura documentada: raíz (`docker-compose.yml`, `.env.example`, CI), backend (FastAPI con `/auth` implementado, `deps.py` con `SET LOCAL app.clinic_id` para RLS, mixins SQLAlchemy, Alembic async, ARQ, `conftest.py`) y frontend (Expo Router + Tamagui, store Zustand, axios con refresh queue, guard de auth).
 
 ### **2.4. Infraestructura y despliegue**
 
@@ -123,99 +106,105 @@ Cambió la estructura de `frontend/` de "React SPA reescribible a React Native" 
 
 > "Vercel + Railway → Railway solo"
 
-Reescritura completa de la sección 7 de architecture.md y figura 2 de entrega1/readme.md. Todos los servicios (frontend estático, backend, ARQ worker, cron, Postgres, Redis) viven en un único proyecto Railway. Reverse proxy interno elimina CORS frontend-backend. Removidas todas las referencias a Vercel y a Render como alternativas.
+Reescritura de la sección de infraestructura: todos los servicios (frontend estático, backend, ARQ worker, cron, Postgres, Redis) viven en un único proyecto Railway. El reverse proxy interno elimina CORS frontend-backend; se removieron las referencias a Vercel y a Render como alternativas.
 
-**Prompt 2:** *(Sesión — estimación de billing)*
+**Prompt 2:** *(Sesión 24 — recordatorios: del plan a la decisión real)*
+
+> *(US-021, AskUserQuestion sobre el schedule del cron)* el usuario simplificó a **una corrida diaria que avisa los turnos de mañana** y **un solo recordatorio** (se descarta el de 48h)
+
+El plan original (recordatorios 48h y 24h, cron cada 15 min) se simplificó a un cron diario `0 8 * * *` (`backend/railway.cron.json`) con `trigger_hours_before=24`. Idempotencia en dos capas: guard `has_sent` + índice UNIQUE parcial `(appointment_id, trigger_hours_before) WHERE status='sent'`. El cron corre sin JWT → bypassa RLS (`app_admin`). La hora se localiza a `clinics.timezone` (se agregó `tzdata` para resolver zonas IANA en Windows/contenedores).
+
+**Prompt 3:** *(Sesión — estimación de billing)*
 
 > "en funcion de las herramientas y tecnologias elegidas, realizame una estimacion de billing para el proyecto como un mvp funcional de pocos usuarios"
 
-Producía tres escenarios (piloto / MVP / validación inicial) con tabla detallada por servicio. Total para MVP de 3 clínicas: ~U$ 55–70/mes. Identificó que el cuello de botella económico no es la infraestructura sino el tiempo de los founders.
-
-**Prompt 3:** *(Sesión — hosting local para piloto inicial)*
-
-> "para una prueba piloto inicial, no podriamos hostear todo local?"
-
-Respuesta en tres escenarios: pre-piloto Docker Compose local ($0), piloto real con mini-PC on-premise en la clínica (~$400 one-time + $0/mes), VPS Hetzner €4/mes como alternativa cloud económica. Conclusión: migrar a Railway cuando haya 2–3 clínicas pagando.
+Produjo una tabla detallada por servicio. Total para un MVP de pocos usuarios: **~U$ 55–70/mes** en Railway-solo (la transcripción usa la capa gratuita de Groq; Claude con prompt caching es marginal a este volumen). Identificó que el cuello de botella económico no es la infraestructura sino el tiempo de los founders.
 
 ### **2.5. Seguridad**
 
 **Prompt 1:** *(Sesión 3 — RLS como defensa en profundidad)*
 
-> "de los cambios sugeridos para estándares 2026, los siguientes puntos los vamos a adoptar, modifica todos los archivos del proyecto para incorporar dichas sugerencias:
-> 8. Defensa en profundidad para multi-tenancy: PostgreSQL Row-Level Security (RLS) además del filtro en queries; tests de regresión que validen aislamiento entre clínicas/clientes.
-> 10. Testing E2E mínimo del flujo IA con Playwright; snapshot tests del prompt enviado a Claude.
-> 11. Si la migración mobile está comprometida, usar Expo desde el día uno (Expo Router + Tamagui o React Native Web)."
+> "de los cambios sugeridos para estándares 2026... 8. Defensa en profundidad para multi-tenancy: PostgreSQL Row-Level Security (RLS) además del filtro en queries; tests de regresión que validen aislamiento entre clínicas."
 
-Incorporó RLS a architecture.md §4 (setup completo: `ENABLE/FORCE ROW LEVEL SECURITY`, policy por tabla, `SET LOCAL app.clinic_id`, usuarios `app_runtime` + `app_admin`). En data-model.md nueva sección con SQL. En prd.md RNF-011 (RLS) y RNF-012 (suite de aislamiento bloqueante en CI).
+Incorporó RLS (setup `ENABLE/FORCE ROW LEVEL SECURITY`, policy por tabla, usuarios `app_runtime`/`app_admin`) + suite de aislamiento bloqueante en CI.
 
-**Prompt 2:** *(Sesión — entidades de auditoría)*
+**Prompt 2:** *(Sesión 3 — entidades de auditoría append-only)*
 
 > "es buena idea/practica incorporar al modelo de datos una entidad que registre los logs/historial de las consultas, transacciones, etc a la DB?" → "si, aplicame los cambios"
 
-Incorporó dos tablas append-only: `audit_log` (mutaciones con diff JSONB, auto-poblada via SQLAlchemy event listener) y `clinical_record_access_log` (lecturas de historias clínicas para cumplir Ley 25.326). Append-only enforced en DB (`REVOKE UPDATE, DELETE`). Retención 7 años + anonimización (no borrado). Restringido a rol `admin`.
+Incorporó dos tablas append-only: `audit_log` (mutaciones con diff JSONB, auto-poblada vía SQLAlchemy `after_flush`) y `clinical_record_access_log` (lecturas de historias clínicas, Ley 25.326). Append-only enforced en motor (`REVOKE UPDATE, DELETE`).
+
+**Prompt 3:** *(Sesión 9a — bug raíz de RLS al ejercerlo contra Postgres real)*
+
+> "cuando se quiere crear un nuevo usuario... al darle al boton crear muestra un mensaje de error inesperado"
+
+`get_current_user` usaba `text("SET LOCAL app.clinic_id = :cid")` y PostgreSQL no acepta parámetros vinculados en `SET` → 500 en toda request autenticada (no detectado por los tests, que mockean sobre SQLite). **Fix:** `SELECT set_config('app.clinic_id', :cid, true)`. US-003 fue la primera feature que ejerció ese camino contra Postgres.
 
 ### **2.6. Tests**
 
 **Prompt 1:** *(Sesión 3 — Playwright + syrupy)*
 
-> "de los cambios sugeridos para estándares 2026, los siguientes puntos los vamos a adoptar, modifica todos los archivos del proyecto para incorporar dichas sugerencias:
-> 8. Defensa en profundidad para multi-tenancy: PostgreSQL Row-Level Security (RLS) además del filtro en queries; tests de regresión que validen aislamiento entre clínicas/clientes.
-> 10. Testing E2E mínimo del flujo IA con Playwright; snapshot tests del prompt enviado a Claude.
-> 11. Si la migración mobile está comprometida, usar Expo desde el día uno (Expo Router + Tamagui o React Native Web)."
+> "10. Testing E2E mínimo del flujo IA con Playwright; snapshot tests del prompt enviado a Claude."
 
-Stack de testing extendido en architecture.md §3: pytest + pytest-asyncio + **Playwright** (E2E del flujo IA end-to-end) + **syrupy** (snapshot del prompt completo + schema enviado a Claude). RNF-013 y RNF-014 en el PRD.
+Stack de testing base: pytest + pytest-asyncio (engine aiosqlite, rollback por test) + **Playwright** (E2E del flujo IA) + **syrupy** (snapshot del prompt + schema enviado a Claude, bloquea merges).
+
+**Prompt 2:** *(Implementación — TDD por capa en `/implement-us`)*
+
+> El flujo `/implement-us` despacha al agente `tdd-specialist` tras cada capa (DB → BE → FE), ejecutando RED→GREEN→REFACTOR.
+
+En implementación se sumó **Jest + React Native Testing Library** para el frontend (mock de Tamagui/Expo Router/Zustand/TanStack Query). Al cierre del MVP la suite backend supera los 570 tests y la de frontend los 400.
+
+**Prompt 3:** *(Implementación — aislamiento multi-tenant + append-only bloqueante)*
+
+> Suite custom de pytest que verifica el aislamiento entre clínicas y que `UPDATE`/`DELETE` sobre `audit_log` desde `app_runtime` falle con `permission denied`.
+
+Es un test **bloqueante en CI**: materializa la garantía de RLS (una clínica no ve filas de otra) y la inmutabilidad append-only directamente contra el motor Postgres, no solo en la capa ORM.
 
 ---
 
 ## 3. Modelo de Datos
 
-**Prompt 1:** *(Sesión 2 — generación inicial)*
+**Prompt 1:** *(Sesión 2 — generación inicial del ERD)*
 
 > "@ia-agents/agents/doc-generator.md genera la documentacion del proyecto"
 
-Generó el ERD inicial en docs/data-model.md con las 10 entidades principales: clinics, users, clients, pets, appointments, appointment_notifications, clinical_records, clinical_attachments, clinical_records_ai, vaccinations + entidades Fase 2.
+Generó el ERD inicial en `data-model.md` con las entidades principales (clinics, users, clients, pets, appointments, clinical_records, clinical_records_ai, vaccinations + tablas de auditoría).
 
-**Prompt 2:** *(Sesión — separación users vs clients)*
+**Prompt 2:** *(Sesión — justificación de separar users vs clients)*
 
-> "se indica la creacion de dos entidades, 'usuarios' y 'clientes', entindo que se hace asi porque se separa el modo de autenticacion respecto a los 'usuarios' propios de la clinica, pero son practicamente iguales. Que justificacion encontras para tener esas 2 entidades y no unificarlas?"
+> "se indica la creacion de dos entidades, 'usuarios' y 'clientes'... Que justificacion encontras para tener esas 2 entidades y no unificarlas?"
 
-Justificación documentada: distintos FKs (created_by → users, owns → clients), distintos ciclos de vida (staff contratado/despedido vs cliente con relación continua), distintos modelos de auth (JWT staff vs JWT portal en Fase 1.5), RLS más simple con tablas separadas. La alternativa "identity + profiles" se reservó para refactor futuro si aparecen ≥10 casos de "staff que también es cliente".
+Justificación: distintos FKs, distintos ciclos de vida, distintos modelos de auth (JWT staff vs JWT portal en Fase 1.5), RLS más simple con tablas separadas.
 
-**Prompt 3:** *(Sesión 3 — schema IA + Fase 1.5)*
+**Prompt 3:** *(Sesiones 15, 18, 19, 21 — materialización incremental en migraciones)*
 
-> "dadas las sugerencias del stack tecnologico revisado y los cambios propuestos, para los puntos:
-> 6. Prompt caching de Anthropic desde el día uno (cuts ~80% de tokens cacheados).
-> 7. Output estructurado con Pydantic + tool use en lugar de JSON suelto.
->
-> no se busca por ahora que el modelo genere diagnosticos ni sugerencias en la historia clinica. Adicionalmente, el entidad de cliente, junto con el portal al que accede el mismo, lo pensamos para una fase 1.5 del proyecto."
+> *(US-009)* `/implement-us 264` — migración `0005` crea `clinical_records` + `audit_log` + listener. *(US-023)* `0006` crea `vaccinations`. *(US-019)* `0007` agrega `cancellation_reason`. *(US-011)* `0008` crea `clinical_record_access_log`. *(US-013)* `0011` crea `clinical_records_ai` append-only.
 
-Tabla `clinical_records_ai` reescrita con `schema_version`, `ai_structured_output` (sin diagnosis/treatment en MVP), `cache_hit_tokens`, `cache_write_tokens`. Tabla `clients` partida en "Fase 1 — campos requeridos" + "Fase 1.5 — campos del Portal" (`portal_enabled`, `password_hash`, `is_active`, `last_login_at`).
+El modelo se materializó incrementalmente en migraciones Alembic `0001`–`0011`, cada tabla dentro del ticket de la US que la necesita primero. Hallazgo recurrente: el `head` de Alembic debía confirmarse con `alembic heads` antes de encadenar `down_revision` (varias US en paralelo colgaban de la misma migración).
 
 ---
 
 ## 4. Especificación de la API
 
-**Prompt 1:** *(Sesión 2 — endpoints iniciales)*
+**Prompt 1:** *(Sesión 3 — endpoint `/ai/extract-record` con alcance acotado)*
 
-> "con toda la informacion de @docs\ completa el archivo @entrega1/readme.md respetando el formato tipo cuestionario, completando los puntos que puedas sin inventar nada."
+> "la idea que tenemos es utilizar un modelo de IA para que, en funcion de una historia clinica con un formato y estructura definidos, se complete la misma con la informacion transcrita... necesito que modifiques los archivos del proyecto para reflejar esta decision."
 
-Generó la primera versión de la spec OpenAPI con 3 endpoints: transcripción IA, historial clínico, creación de turno.
+El endpoint pasó de `/ai/generate-record` (genera todo) a un contrato de estructuración de los campos extraíbles.
 
-**Prompt 2:** *(Sesión 3 — endpoint `/ai/extract-record`)*
+**Prompt 2:** *(Sesión 27 — implementación del flujo IA real, US-013)*
 
-> "dadas las sugerencias del stack tecnologico revisado y los cambios propuestos, para los puntos:
-> 6. Prompt caching de Anthropic desde el día uno (cuts ~80% de tokens cacheados).
-> 7. Output estructurado con Pydantic + tool use en lugar de JSON suelto.
->
-> la idea que tenemos es utilizar un modelo de IA para que, en funcion de una historia clinica con un formato y estructura definidos, se complete la misma con la informacion transcrita de el audio/imagen/texto que cargue el especialista. necesito que modifiques los archivos del proyecto para reflejar esta decision."
+> `/implement-us 268`
 
-El endpoint cambió de `/ai/generate-record` (genera todo) a `/ai/extract-record` (estructura los campos extraíbles). Response schema actualizado: `consultation_reason`, `symptoms`, `weight_kg`, `temperature_c`, `medication_taken` + `diagnosis: null`, `treatment: null` con descripción explícita "Siempre null en MVP — completar manualmente".
+Materializó el flujo IA: `POST /ai/transcribe-voice` (202 + task_id), `GET /ai/tasks/{task_id}` (polling), y el pipeline ARQ **Groq Whisper (`whisper-large-v3`) → Claude Haiku cleanup → Claude Sonnet tool use**. Decisiones reales: Groq Whisper vía SDK de OpenAI con `base_url` override; el worker crea su propia sesión con `set_config` para RLS; subida del SDK `anthropic` a `0.111.0` y corrección de model IDs (`claude-haiku-4-5-20251001`, `claude-sonnet-4-6`).
 
-**Prompt 3:** *(Sesión — completar entrega1 con OpenAPI actualizado)*
+**Prompt 3:** *(Sesión 28 — segundo endpoint del flujo IA, US-014)*
 
-> "ahora necesito que con la informacion actual del proyecto y de los archivos incluidos en el, me completes los documentos @entrega1/prompts.md y @entrega1/readme.md"
+> `/implement-us 269`
 
-Regeneró la spec OpenAPI con los tres endpoints del flujo IA reflejando todas las decisiones de Sesión 3 (alcance acotado, prompt caching, snapshot tests, RLS, auditoría automática).
+`POST /ai/transcribe-upload` para subir un archivo de audio externo: valida formato (MIME con fallback a extensión) y tamaño (413 para > 20 MB), reutiliza el mismo pipeline ARQ con `input_type="upload"`. Reutilización masiva de US-013 (tabla, schema y polling sin cambios).
+
+> **Otros endpoints implementados** a lo largo del MVP: `/auth/*` (register/login/refresh/logout/forgot-password/reset-password), `/users`, `/clients`, `/pets` (+ perfil agregado), `/search`, `/appointments` (crear/listar/reprogramar/cancelar/marcar-atendido/notifications), `/clinical-records` (crear/ver/editar/borrar/by-appointment/attachments), `/pets/{id}/vaccinations`, e internos (`/internal/notifications/send-reminders`).
 
 ---
 
@@ -225,90 +214,60 @@ Regeneró la spec OpenAPI con los tres endpoints del flujo IA reflejando todas l
 
 > "@ia-agents/agents/doc-generator.md genera la documentacion del proyecto"
 
-Generó 32 historias de usuario distribuidas en 10 módulos (Autenticación, Clientes, Mascotas, Historia Clínica, IA, Turnos, Notificaciones, Vacunación, Reportes, Offline).
+Generó 32 historias de usuario distribuidas en módulos.
 
 **Prompt 2:** *(Sesión 3 — ajuste de US-013/014/015 por scope IA)*
 
-> "dadas las sugerencias del stack tecnologico revisado y los cambios propuestos, para los puntos:
-> 6. Prompt caching de Anthropic desde el día uno (cuts ~80% de tokens cacheados).
-> 7. Output estructurado con Pydantic + tool use en lugar de JSON suelto.
->
-> no se busca por ahora que el modelo genere diagnosticos ni sugerencias terapeuticas. reescribí las historias de usuario del módulo de historia clínica asistida por IA para reflejar este alcance acotado."
+> "no se busca por ahora que el modelo genere diagnosticos ni sugerencias terapeuticas. reescribí las historias de usuario del módulo de historia clínica asistida por IA para reflejar este alcance acotado."
 
-Las historias del Módulo 4 (US-013 a US-016) se reescribieron: ya no piden "obtener la historia clínica generada" sino "que la app complete los campos predefinidos a partir de lo dictado"; los campos `diagnóstico` y `tratamiento` quedan vacíos en el pre-fill; US-015 (imagen) pasa de "diagnóstico sugerido" a "descripción objetiva de lo visible".
+Las historias del Módulo 4 se reescribieron: "que la app complete los campos predefinidos a partir de lo dictado".
 
-**Prompt 3:** *(Sesión — incorporación de historias de auditoría)*
+**Prompt 3:** *(Sesión 22 — US emergente durante la implementación: nace US-020b)*
 
-> "es buena idea/practica incorporar al modelo de datos una entidad que registre los logs/historial [...] si, aplicame los cambios"
+> "estaria bien que si ya tiene una consulta cargada, al clickear te la muestre y puedas modificarla, no seguir cargando otras" → "Si, crea la US-020-b asi se sabe que continua a esta"
 
-Nuevo Módulo 12 con tres historias: US-039 (Admin ve historial de cambios con diff campo-por-campo), US-040 (Admin ve registro de accesos a una historia clínica), US-041 (Admin exporta auditoría de un período a Excel/CSV).
+Probando US-020 (marcar atendido) se detectó que se podían cargar historias duplicadas por turno y no había forma de ver la ya cargada. El `user-story-agent` redactó **US-020b** (issues #402/#403/#404): `GET /clinical-records/by-appointment/{id}` + `PATCH` de edición auditada + guard 409 anti-duplicado, y modo edición en el modal. Ejemplo de cómo el testing manual de una US generó la siguiente.
 
 ---
 
-### 6. Tickets de Trabajo
+## 6. Tickets de Trabajo
 
-**Prompt 1:** *(Sesión de generación de tickets — invocación del user-story-agent + estrategia modular)*
+**Prompt 1:** *(Sesión de generación — estrategia modular)*
 
-> "genera los tickets de trabajo para cada historia de usuario en `@docs/user-stories.md`, aplicando el formato BDD con criterios Dado que / Cuando / Entonces, evaluación INVEST y estimación de talla S/M/L"
+> "genera los tickets de trabajo para cada historia de usuario en @docs/user-stories.md, aplicando el formato BDD con criterios Dado que / Cuando / Entonces, evaluación INVEST y estimación de talla S/M/L"
 
-El agente `user-story-agent` detectó que procesar las 41 historias de usuario en una sola invocación superaría el límite de tokens de output (~32K). Se adoptó la estrategia **módulo por módulo con ediciones quirúrgicas**: cada agente recibe un único módulo, lee la sección correspondiente del archivo y usa `old_string/new_string` para insertar los tickets directamente antes del separador `---` de cada US, sin reescribir el archivo completo. Esto permitió procesar los 11 módulos (US-001 a US-041 más módulos diferidos) en rondas de agentes paralelos independientes.
+El `user-story-agent` procesó los módulos uno por uno con ediciones quirúrgicas (límite de tokens de output). Resultado inicial: 82 tickets (41 BE + 41 FE).
 
-Resultado: 82 tickets insertados (41 BE + 41 FE), con 3 escenarios BDD por ticket (happy path, edge case, error) y evaluación INVEST completa. Los tickets de los módulos diferidos (Portal del Cliente — Fase 1.5, Offline — Fase 2) recibieron `I⚠️` en INVEST para señalar que su independencia está condicionada a la implementación de la Fase 1.
-
-**Prompt 2:** *(Sesión — extensión del modelo a 5 capas de desarrollo)*
+**Prompt 2:** *(Sesión 4 — modelo de 5 capas)*
 
 > "@.claude/agents/user-story-agent.md indica al agente que se debe generar user story y tickets de todo el espectro de desarrollo, no solo backend y frontend"
 
-El agente `user-story-agent` solo generaba tickets `-BE` y `-FE`. Se actualizaron ambas copias del agente (`.claude/agents/user-story-agent.md` y `ia-agents/agents/user-story-agent.md`) para definir el modelo de 5 capas:
+Se definió el modelo de 5 capas (`-BE`, `-FE`, `-DB`, `-INFRA`, `-AI`), creando ticket de capa separado solo cuando ese trabajo puede asignarse a otra persona, tiene criterios propios y se testea de forma autónoma. Aplicado retroactivamente: total **91 tickets**, importados a GitHub Issues con `scripts/import_to_github.py` (labels por capa).
 
-| Sufijo | Capa | Cuándo generarlo |
-|---|---|---|
-| `-BE` | Backend | endpoint, lógica de negocio, worker ARQ, cron job |
-| `-FE` | Frontend | pantalla, componente, hook, flujo UI |
-| `-DB` | Base de datos | migración Alembic nueva, tabla, índice, RLS policy, append-only |
-| `-INFRA` | Infraestructura | Railway env vars, cron schedule, CI/CD, Docker, secrets, S3 |
-| `-AI` | IA / Integración | prompt nuevo, schema Pydantic de extracción, selección de modelo, prompt caching |
+**Prompt 3:** *(Sesión 7 — planificación por US con el agente `planning-specialist`)*
 
-La regla de decisión incorporada: crear ticket de capa separado solo cuando ese trabajo puede asignarse a una persona distinta, tiene criterios de aceptación propios y puede testearse independientemente. El workflow del agente se extendió con los pasos 6 ("Para cada capa involucrada → generar ticket con sufijo correcto") y 7 ("Marcar dependencias entre tickets").
+> "Bien, faltaria que el plan de implementacion sea un poco mas detallado. Que se podria agregar?" + "porque se crea un agente y no una skill?"
 
-**Prompt 3:** *(Sesión — aplicación retroactiva de los nuevos criterios a los 82 tickets existentes)*
-
-> "@.claude/agents/user-story-agent.md modifica los tickets generados en `@docs/user-stories.md` considerando los nuevos criterios"
-
-Se analizaron los 82 tickets existentes aplicando el criterio de las 5 capas. Se identificaron 9 user stories que requieren tickets adicionales de base de datos, infraestructura o IA — aquellos donde el trabajo de esas capas es suficientemente autónomo para asignarse y testearse independientemente:
-
-| Ticket nuevo | US | Justificación |
-|---|---|---|
-| `US-001-DB` | Registro de clínica | Migración inicial con setup de RLS, roles `app_runtime`/`app_admin` y FORCE ROW LEVEL SECURITY — prerequisito de todo el sistema |
-| `US-001-INFRA` | Registro de clínica | Variables de entorno Railway + `.env.example` para todos los servicios del MVP |
-| `US-013-DB` | Voz → campos clínicos | Tabla `clinical_records_ai` append-only con REVOKE + índice compuesto — independiente del endpoint BE |
-| `US-013-AI` | Voz → campos clínicos | System prompt de extracción, schema Pydantic `ClinicalRecordExtraction`, selección haiku/sonnet, prompt caching + tests syrupy bloqueantes |
-| `US-014-AI` | Audio uploaded | Verificación de reutilización del pipeline + guard de selección de modelo para audio upload |
-| `US-015-AI` | Imagen → síntomas | Prompt Vision para `claude-sonnet-4-6`, campo `image_observations`, guard que prohíbe haiku en flujo imagen |
-| `US-021-INFRA` | Recordatorios de turno | Cron job Railway `0 8 * * *` + `RESEND_API_KEY` — configuración independiente del endpoint de envío |
-| `US-039-DB` | Historial de cambios | Tabla `audit_log` append-only + listener SQLAlchemy `after_flush` + índices compuestos para queries de auditoría |
-| `US-040-DB` | Registro de accesos | Tabla `clinical_record_access_log` append-only con REVOKE para trazabilidad de lecturas (Ley 25.326) |
-
-Total final: **91 tickets** (41 BE · 41 FE · 4 DB · 2 INFRA · 3 AI) · 41 US cubiertas · Fase 1 MVP: 65 tickets · Fase 1.5 + Fase 2: 26 tickets. La tabla de resumen al final de `docs/user-stories.md` se actualizó con las nuevas entradas y los totales corregidos.
+Se creó el agente `planning-specialist`, invocado en el Paso 0 de `/implement-us`: lee el issue padre + cada ticket con sus criterios BDD + el codebase, y genera `docs/changelog/US-XXX.md` con seis componentes por ticket (criterios de done, archivos esperados, contrato de interfaz, riesgos, scope explícito y dependencias). El aislamiento de contexto del agente evita inflar el del orquestador. Cada US implementada (US-001 a US-014, US-017 a US-023, US-DASH) tiene su `docs/changelog/US-XXX.md`.
 
 ---
 
 ## 7. Pull Requests
 
-**Prompt 1:** *(Sesión 1 — flujo inicial de PRs)*
+**Prompt 1:** *(Sesión 6 — definición del flujo git/board)*
 
-> "podes crearme una rama 'docs', hacer un commit con todo lo realizado y luego realizar el push? siempre consultandome antes de ejecutar algun comando"
+> "como seria el flujo de manejo de git?" + "las issues de github issues y del project como las manejas?"
 
-Creación de la rama `docs` y primer push a `origin/docs`. Establecimiento de la convención de hacer todos los commits de documentación en esa rama hasta validar con tutores.
+Se definió el flujo: rama `feat/us-XXX` desde `dev` actualizado; un commit por ticket (conventional commits); `gh pr create --base dev` con `Closes #N`; integración con GitHub Projects v2 (Todo → In Progress al iniciar → In Review al crear el PR → Done **manual** tras el merge, porque el PR apunta a `dev`, no a `main`).
 
-**Prompt 2:** *(Sesión 3 — commit de la revisión arquitectónica completa)*
+**Prompt 2:** *(Sesión 23 — cierre y limpieza de una US)*
 
-> "realiza un commit con todos los cambios realizados, agrega un comentario descriptivo y subi los cambios a la rama docs"
+> "si, arranca. Ya hice el pr y me movi a dev haciendo pull"
 
-Disparó la creación del commit `aeeacff docs: revise architecture for MVP scope and 2026 standards` (11 archivos, +1994/−409 líneas) agrupando todos los cambios de Sesión 3 en cuatro bloques temáticos (scope decisions, infrastructure simplifications, AI scope and tooling, standards 2026). Push exitoso a `origin/docs`.
+Patrón de cierre real por US: mergear el PR a `dev`, mover los issues (padre + tickets) a Done manualmente, limpiar la rama (`git push origin --delete`, `git fetch --prune`), y actualizar `prompts.md`/`README.md`/`CLAUDE.md` cuando la feature cambia el comportamiento documentado.
 
-**Prompt 3:** *(Sesión — patrón de PRs documentadas)*
+**Prompt 3:** *(Sesiones 9–28 — síntesis del resultado)*
 
-> Convención implícita establecida en toda la sesión: cada cambio relevante sobre los docs se acompaña con un mensaje de commit estructurado siguiendo conventional commits (`docs:`, `feat:`, `fix:` prefixes), y los cambios grandes se agrupan por temática para que el `git log` cuente la historia del proyecto sin necesidad de leer cada diff.
+> Convención sostenida durante toda la implementación: un PR por User Story sobre `dev`, con changelog por ticket y testing manual contra Postgres real antes de cerrar.
 
-Los PRs reales (cuando inicie Fase 1 con scaffolding de código) seguirán este patrón: PRs chicas y enfocadas, mensajes descriptivos con bloques temáticos, CI bloqueante con suite de tests de aislamiento RLS + snapshot del prompt antes del merge.
+Se completaron **24 PRs mergeados a `dev`** (`#388`–`#418`): US-001 a US-014, US-017 a US-023, US-DASH y un fix de UX de adjuntos. Cada PR cierra su issue padre y sus tickets, con la suite de tests (backend > 570, frontend > 400) y, para los flujos críticos, specs de Playwright. Los PRs a `main` quedan para el cierre de Fase 1.

--- a/readme.md
+++ b/readme.md
@@ -23,19 +23,21 @@ Veterinary Intelligence Platform
 
 ### **0.3. Descripción breve del proyecto:**
 
-Plataforma web SaaS multi-tenant para la gestión integral de clínicas veterinarias pequeñas (1–5 veterinarios). El diferenciador central es la **asistencia de IA para estructurar historias clínicas**: el veterinario dicta una nota de voz, sube una imagen diagnóstica o ingresa texto libre, y el sistema transcribe y completa automáticamente los campos predefinidos del registro clínico (motivo, síntomas, peso, temperatura, medicación referida). El profesional revisa y confirma antes de guardar. **La IA del MVP no genera diagnósticos ni tratamientos sugeridos** — esa capacidad queda diferida a una etapa posterior con validación regulatoria.
+Plataforma web SaaS multi-tenant para la gestión integral de clínicas veterinarias pequeñas (1–5 veterinarios). El diferenciador central es la **asistencia de IA para estructurar historias clínicas**: el veterinario graba una nota de voz (o sube un archivo de audio) y el sistema transcribe y completa automáticamente los campos predefinidos del registro clínico (motivo, síntomas, peso, temperatura, medicación referida y —cuando el profesional los dicta explícitamente— diagnóstico y tratamiento). El profesional revisa y confirma antes de guardar. **La IA nunca inventa diagnósticos ni tratamientos**: solo estructura lo que el veterinario efectivamente dictó.
 
-El sistema cubre además gestión de clientes y mascotas, agenda multi-veterinario con detección de solapamientos, vacunación con recordatorios de vencimiento, notificaciones automáticas de turno por email, reportes exportables y auditoría completa de cambios sobre datos clínicos.
+El sistema cubre además gestión de usuarios staff, clientes y mascotas, agenda multi-veterinario con detección de solapamientos (Schedule-X), perfil clínico completo de la mascota, historial clínico con adjuntos (imágenes/PDF), registro de vacunación, recordatorios automáticos de turno por email y auditoría inmutable de cambios y accesos sobre datos clínicos.
+
+> **Estado actual (junio 2026):** el proyecto pasó de la fase de documentación a un **MVP funcional**. Hay backend (FastAPI), frontend (Expo + Tamagui) y base de datos (PostgreSQL 16 con RLS) implementados y ejecutables localmente. Se completaron 24 pull requests sobre la rama `dev` (US-001 a US-014, US-017 a US-023 y US-DASH). El flujo diferenciador de IA (voz → campos clínicos) está operativo end-to-end.
 
 ### **0.4. URL del proyecto:**
 
-> Producto aún no desplegado en producción — el proyecto se encuentra en fase de documentación técnica y planificación. No hay URL pública del MVP.
+> Producto aún no desplegado en producción (no hay URL pública). El MVP es **ejecutable localmente** con Docker Compose + los scripts `backend/start.ps1` y `frontend/start.ps1` (frontend en `http://localhost:8081`, backend en `http://localhost:8000`). El deploy en Railway está documentado pero pendiente de configurar.
 
 ### 0.5. URL o archivo comprimido del repositorio
 
 https://github.com/mateocostes/Veterinary-Intelligence-Platform
 
-Branch principal: `main`. Toda la documentación técnica de esta entrega vive en la rama `docs` (commit `aeeacff` al momento de la entrega).
+Branch principal: `main`. El desarrollo activo del MVP vive en la rama **`dev`** (24 PRs mergeados, `feat/us-XXX → dev`). La documentación técnica vive en `docs/`.
 
 ---
 
@@ -43,56 +45,80 @@ Branch principal: `main`. Toda la documentación técnica de esta entrega vive e
 
 ### **1.1. Objetivo:**
 
-El producto resuelve un problema cuantificable de las clínicas veterinarias pequeñas: **la documentación clínica manual consume ~10 minutos por consulta**, tiempo que el veterinario no puede dedicar al paciente. La plataforma reduce ese tiempo a **menos de 3 minutos por consulta** estructurando automáticamente la historia clínica a partir de lo que el profesional dicta.
+El producto resuelve un problema cuantificable de las clínicas veterinarias pequeñas: **la documentación clínica manual consume ~10 minutos por consulta**, tiempo que el veterinario no puede dedicar al paciente. La plataforma reduce ese tiempo estructurando automáticamente la historia clínica a partir de lo que el profesional dicta.
 
 **Valor por stakeholder:**
 
-- **Veterinario:** dicta una nota de voz mientras atiende; recibe los campos pre-completados con la información transcrita; revisa, edita lo que necesite y guarda con un click. Reduce la fricción administrativa.
+- **Veterinario:** graba una nota de voz mientras atiende; recibe los campos pre-completados con la información transcrita; revisa, edita lo que necesite y guarda con un click. Reduce la fricción administrativa.
 - **Recepcionista:** gestiona agenda multi-profesional sin solapamientos; el sistema dispara recordatorios automáticos de turno sin llamadas manuales.
-- **Administrador (dueño de la clínica, que suele también ejercer como veterinario):** ve reportes operativos y financieros; audita cambios sobre historias clínicas; controla quién accedió a qué información (cumplimiento Ley 25.326).
+- **Administrador (dueño de la clínica, que suele también ejercer como veterinario):** gestiona el staff de la clínica; ve el perfil clínico completo de cada mascota; audita cambios sobre historias clínicas; controla quién accedió a qué información (cumplimiento Ley 25.326).
 - **Dueño de mascota:** recibe recordatorios automáticos por email; en Fase 1.5 accederá a un portal propio para consultar historial y autogestionar turnos.
 
 **Para quién:** clínicas veterinarias pequeñas argentinas de 1–5 veterinarios, donde el dueño suele también ejercer como profesional clínico, con eventual recepcionista, y con acceso a internet estable durante las consultas.
 
 ### **1.2. Características y funcionalidades principales:**
 
-| Feature | Descripción |
-|---|---|
-| **Historia Clínica Asistida por IA** | Transcripción de voz (Whisper API `whisper-1`) + **estructuración** del contenido en los campos predefinidos de la historia clínica (Claude API con tool use + schema Pydantic; modelo seleccionado por subtarea entre `claude-haiku-4-5` y `claude-sonnet-4-6`). **Prompt caching activado desde el día uno**. La IA NO genera diagnósticos ni tratamientos sugeridos en el MVP — esa capacidad se difiere a una etapa posterior. El veterinario valida y edita antes de guardar. Toda la interacción IA queda auditada en `clinical_records_ai`. |
-| **Gestión de Clientes y Mascotas** | CRUD completo de clientes y pacientes. Perfil unificado que integra historial clínico, vacunas y próximos turnos. Búsqueda por nombre de mascota o dueño con respuesta en < 1 segundo. |
-| **Agenda y Turnos** | Vista diaria y semanal filtrable por veterinario (Schedule-X). Detección de solapamiento de turnos. Estados: Pendiente / Atendido / Cancelado. Transición directa turno → creación de historia clínica. |
-| **Notificaciones Automáticas** | Recordatorios de turno por email (Resend) a 48h y 24h del turno, disparados desde un cron de Railway que corre cada 15 min. Registro del estado de cada envío en `appointment_notifications`. |
-| **Vacunación y Recordatorios** | Registro de vacunas aplicadas con próxima fecha. Listado de vencimientos próximos en los 30 días siguientes (configurable), filtrables por especie y veterinario. Cron diario `notify_due_vaccinations.py` que notifica a la clínica. |
-| **Reportes y Exportación** | Consultas por período, ingresos, mascotas atendidas y vacunas aplicadas. Exportación en PDF y Excel. Reportes financieros sólo para Administrador. |
-| **Auditoría y Trazabilidad** | Registro automático e inmutable de todas las mutaciones sobre datos clínicos/de negocio (`audit_log` con event listener de SQLAlchemy) y de los accesos individuales a historias clínicas (`clinical_record_access_log`). Append-only enforced en motor (`REVOKE UPDATE, DELETE` al rol `app_runtime`). Visible para el Administrador con filtro por entidad y por usuario. |
+| Feature | Estado | Descripción |
+|---|---|---|
+| **Autenticación y multi-tenancy** | ✅ Implementado | Registro de clínica (crea Clinic + User admin atómicamente), login con JWT + refresh tokens en Redis, recuperación de contraseña por email, gestión de usuarios staff (Admin/Vet/Reception) con RBAC. Aislamiento entre clínicas con `clinic_id` + PostgreSQL Row-Level Security. |
+| **Historia Clínica Asistida por IA** | ✅ Implementado | Grabación de voz (MediaRecorder web) o subida de archivo de audio → transcripción con **Groq Whisper (`whisper-large-v3`)** → limpieza con **`claude-haiku-4-5`** → **estructuración** en los campos predefinidos con **`claude-sonnet-4-6`** (tool use + schema Pydantic `ClinicalRecordExtraction`, **prompt caching** activo). La IA extrae motivo, síntomas, peso, temperatura, medicación referida y —solo si el vet los dicta explícitamente— diagnóstico y tratamiento; **nunca los inventa**. Pipeline asíncrono vía ARQ con polling y fallback manual. Toda interacción IA queda auditada en `clinical_records_ai` (append-only). |
+| **Gestión de Clientes y Mascotas** | ✅ Implementado | CRUD de clientes y mascotas. Perfil clínico unificado de la mascota (datos básicos + últimas consultas + vacunas + próximos turnos). Búsqueda global por nombre de mascota o dueño con resultado enriquecido (mascota + dueño + próximo turno). |
+| **Agenda y Turnos** | ✅ Implementado | Vista diaria y semanal filtrable por veterinario (Schedule-X, español, anclada al lunes). Detección de solapamiento (HTTP 409). Reprogramar / cancelar (cancelación lógica que libera el horario). Marcar atendido (`pending → attended`) e iniciar/registrar la consulta desde el turno; ver/editar la consulta ya cargada (una por turno). |
+| **Adjuntos clínicos** | ✅ Implementado | Subida de imágenes/PDF (≤ 20 MB, máx. 10) a una consulta, validando el lote completo antes de subir. Almacenamiento en **Supabase Storage** (bucket privado `clinical-attachments`, URLs firmadas de corta vida). Grilla de miniaturas, apertura en pestaña nueva y borrado (soft delete auditado). |
+| **Vacunación** | ✅ Implementado | Registro de vacunas aplicadas con próxima fecha de vencimiento, opcionalmente vinculadas a una consulta. |
+| **Notificaciones Automáticas** | ✅ Implementado | Recordatorio de turno por email vía **SMTP (`aiosmtplib`)**, disparado por un **cron diario de Railway (`0 8 * * *`)** que avisa los turnos de mañana (un recordatorio, idempotente). Estado de cada envío visible en la agenda para admin/reception. |
+| **Auditoría y Trazabilidad** | ✅ Implementado | Registro automático e inmutable de mutaciones (`audit_log`, vía event listener de SQLAlchemy `after_flush`) y de accesos individuales a historias clínicas (`clinical_record_access_log`). Append-only enforced en motor (`REVOKE UPDATE, DELETE` al rol `app_runtime`). |
+| **Reportes** | 🟡 Parcial | Endpoints de reportes operativos/financieros y de auditoría en el backend; UI de reportes pendiente. |
 
 > **Features diferidos.**
-> - **Portal del Cliente (Fase 1.5):** autenticación independiente para dueños de mascotas (JWT propio con `client_id`); permite ver historial clínico filtrable por veterinario y solicitar/cancelar turnos propios; sin acceso a notas internas ni datos de auditoría IA.
-> - **Soporte Offline (Fase 2):** Service Workers + IndexedDB con caché local de turnos del día e historiales frecuentes y cola de mutaciones sincronizada al reconectar.
-> - **Generación de diagnósticos sugeridos con IA (Fase 2):** requiere validación clínica y regulatoria independiente antes de habilitarse.
-> - **Observabilidad completa (Fase 2):** Sentry + Pydantic Logfire / OpenTelemetry + PostHog. MVP se sostiene con logging estructurado de FastAPI.
+> - **Portal del Cliente (Fase 1.5):** autenticación independiente para dueños de mascotas; ver historial filtrable por veterinario y solicitar/cancelar turnos propios. Los emails de recordatorio ya enlazan a una landing pública informativa (`/appointments/{id}`); la acción real es Fase 1.5.
+> - **Soporte Offline (Fase 2):** Service Workers + IndexedDB con caché local y cola de mutaciones.
+> - **Generación de diagnósticos sugeridos con IA (Fase 2):** la IA del MVP solo estructura lo dictado; generar diagnósticos propios requiere validación clínica y regulatoria independiente.
+> - **Observabilidad completa (Fase 2):** Sentry + Pydantic Logfire / OpenTelemetry + PostHog. El MVP se sostiene con logging estructurado de FastAPI.
 
 ### **1.3. Diseño y experiencia de usuario:**
 
-> El proyecto se encuentra en fase de documentación y planificación. El diseño de interfaz y los flujos de usuario aún no han sido implementados. Los wireframes y capturas de pantalla estarán disponibles una vez iniciado el desarrollo del frontend (Fase 1).
+La interfaz está implementada sobre el design system **"Clinical Serenity"** (extraído del proyecto Stitch `VetCare Digital Hub`), codificado como tokens semánticos de marca en `frontend/tamagui.config.ts` (`$brandPrimary` teal médico `#0d9488`, `$surface`, `$onSurface`, `$inputBorder`, `$radiusCard`…) y documentado en `docs/design-system.md`. La app monta `TamaguiProvider` con `defaultTheme="light"`. Cada componente consume **solo** estos tokens (regla R11), nunca hex crudos.
 
-Los flujos principales definidos son:
+Flujos principales implementados:
 
-- **Flujo de consulta con IA:** Veterinario abre ficha de mascota → graba nota de voz → espera transcripción (indicador de carga) → recibe formulario pre-completado con los campos extraídos del audio (motivo, síntomas, peso, temperatura, medicación) → los campos `diagnóstico` y `tratamiento` quedan vacíos para que el profesional los complete → guarda con un click.
-- **Flujo de agenda:** Vista de calendario (Schedule-X) → click en slot disponible → selección de mascota y veterinario → confirmación con detección de solapamiento → recordatorios automáticos por email a 48h y 24h.
-- **Flujo de auditoría:** Administrador entra al detalle de una historia clínica → panel "Historial de cambios" muestra timestamp + usuario + diff campo por campo de cada modificación → panel "Registro de accesos" muestra quién vio la historia y cuándo.
+- **Dashboard por rol:** tarjetas de navegación con visibilidad según rol (admin/vet/reception), saludo dinámico y barra de búsqueda global.
+- **Flujo de consulta con IA:** turno → "Marcar atendido" → "Registrar consulta" → grabar/subir audio → indicador de procesamiento → formulario pre-llenado con los campos extraídos → editar → guardar (con opción de adjuntar archivos).
+- **Flujo de agenda:** calendario Schedule-X día/semana → filtro por veterinario → "Nuevo turno" (búsqueda de mascota + selección de vet, detección de solapamiento) → click en un turno pendiente para reprogramar/cancelar.
+- **Perfil de mascota:** datos básicos + historial clínico (acordeón paginado) + vacunas + próximos turnos.
 
-> **Flujos diferidos:** Portal del Cliente (Fase 1.5) — login independiente, listado de mascotas propias, historial cronológico filtrable por veterinario, solicitud de turno.
+> **Capturas:** la UI es funcional y verificada manualmente en navegador a lo largo del desarrollo (ver `docs/changelog/US-*.md`). Las capturas formales se agregarán en la próxima iteración de documentación.
 
 ### **1.4. Instrucciones de instalación:**
 
-> El proyecto está en fase de documentación. El scaffolding de código aún no ha sido generado. Las instrucciones definitivas estarán disponibles una vez completada la Fase 1 del desarrollo. La planificación contempla:
+**Infraestructura local (Docker):**
+```powershell
+docker-compose up -d postgres redis     # PostgreSQL 16 + Redis 7 (ambos healthy)
+```
 
-- `docker-compose.yml` para levantar el entorno de desarrollo local (PostgreSQL 16, Redis, Backend FastAPI, Frontend Expo + Vite, ARQ Worker)
-- Variables de entorno en `.env.example` (API keys de OpenAI, Anthropic, Resend, configuración de S3/Supabase, `JWT_SECRET`)
-- Migraciones de base de datos via Alembic (`alembic upgrade head`) — incluyen la activación de Row-Level Security y los GRANTs append-only sobre `audit_log` / `clinical_record_access_log`
-- Datos semilla para desarrollo local (clínica de prueba, usuarios staff, mascotas, turnos)
-- Suite de tests bloqueante en CI: `pytest` para unitarios/integración, `playwright` para E2E del flujo crítico de IA, `syrupy` para snapshot tests del prompt enviado a Claude
+**Backend (FastAPI):**
+```powershell
+.\backend\start.ps1    # crea venv + instala deps + aplica migraciones + uvicorn (lee .env de la raíz)
+# Worker ARQ (para el flujo IA):
+.\.venv\Scripts\python.exe -m arq app.worker.settings.WorkerSettings
+```
+
+**Frontend (Expo web):**
+```powershell
+.\frontend\start.ps1   # instala deps si faltan + expo start --web (http://localhost:8081)
+```
+
+**Variables de entorno (`.env` en la raíz, ver `.env.example`):** `DATABASE_URL` / `DATABASE_URL_SYNC`, `JWT_SECRET`, `SMTP_*` (host/port/user/password/from), `GROQ_API_KEY` (Whisper), `ANTHROPIC_API_KEY` (Claude), `SUPABASE_URL` / `SUPABASE_KEY` (adjuntos). Las migraciones (Alembic `0001`–`0011`) crean el schema, activan Row-Level Security y aplican los GRANTs append-only sobre `audit_log` / `clinical_record_access_log` / `clinical_records_ai`.
+
+**Tests:**
+```powershell
+# Backend
+Set-Location backend; python -m pytest
+# Frontend
+Set-Location frontend; npx jest
+# E2E
+Set-Location e2e; npx playwright test --project=chromium
+```
 
 ---
 
@@ -100,35 +126,31 @@ Los flujos principales definidos son:
 
 ### **2.1. Diagrama de arquitectura:**
 
-La arquitectura sigue un patrón de tres capas desacopladas: frontend SPA, backend API REST y base de datos relacional. Los servicios de IA se consumen como APIs externas. El almacenamiento de archivos es independiente de la base de datos. **Todos los servicios viven en un único proyecto de Railway** para simplificar la operación y eliminar CORS interno entre frontend y backend.
+La arquitectura sigue un patrón de tres capas desacopladas: frontend (Expo + React Native Web), backend API REST (FastAPI) y base de datos relacional (PostgreSQL). Los servicios de IA y email se consumen como APIs externas. El almacenamiento de archivos es independiente de la base de datos. **Todos los servicios se planifican en un único proyecto de Railway** para simplificar la operación y eliminar CORS interno.
 
 ```mermaid
 flowchart TD
   subgraph Client["Cliente (Browser / iOS / Android)"]
-    FE["Expo Router + Tamagui<br/>+ Vite (web) / React Native (móvil)<br/>Schedule-X · TanStack Table"]
+    FE["Expo Router + Tamagui<br/>React Native Web (web)<br/>Schedule-X · TanStack Table"]
   end
 
   subgraph Railway["Railway project (single)"]
     STATIC["Frontend (Static — nginx)"]
     API["FastAPI Backend<br/>Auth (JWT) · Business Logic · AI Orchestration<br/>+ PostgreSQL RLS por sesión"]
-    ARQ["ARQ Worker<br/>(flujo IA async)"]
-    CRON["Cron jobs<br/>send_appointment_reminders.py · notify_due_vaccinations.py"]
-    RED["Redis managed<br/>(broker ARQ + refresh tokens)"]
+    ARQ["ARQ Worker<br/>(pipeline IA async)"]
+    CRON["Cron job diario<br/>send_appointment_reminders.py (0 8 * * *)"]
+    RED["Redis managed<br/>(broker ARQ + refresh tokens + task results)"]
     PG["PostgreSQL 16 managed<br/>Multi-tenancy + Row-Level Security<br/>+ audit_log append-only"]
   end
 
   subgraph Storage["Almacenamiento de archivos"]
-    S3["Supabase Storage / S3<br/>(adjuntos clínicos + audios temp)"]
+    S3["Supabase Storage<br/>(bucket privado clinical-attachments)"]
   end
 
   subgraph External["APIs Externas"]
-    WHISPER["Whisper API (OpenAI)<br/>transcripción de voz"]
-    CLAUDE["Claude API (Anthropic)<br/>estructuración con tool use + Pydantic"]
-    RESEND["Resend<br/>emails transaccionales"]
-  end
-
-  subgraph Deploy["CI/CD"]
-    GHA["GitHub Actions<br/>lint → test → snapshot → build → deploy"]
+    WHISPER["Groq Whisper API<br/>whisper-large-v3 (transcripción)"]
+    CLAUDE["Claude API (Anthropic)<br/>haiku-4-5 cleanup + sonnet-4-6 tool use"]
+    SMTP["SMTP (aiosmtplib)<br/>emails transaccionales"]
   end
 
   FE -->|HTTPS| STATIC
@@ -140,115 +162,95 @@ flowchart TD
   ARQ --> WHISPER
   ARQ --> CLAUDE
   CRON --> PG
-  CRON --> RESEND
-  GHA --> Railway
+  CRON --> SMTP
 ```
 
 *Figure 1: Diagrama de arquitectura general del sistema*
 
-**Patrón elegido:** Arquitectura de tres capas (Presentation / Application / Data) con orquestación async desacoplada (ARQ) para tareas de larga duración y cron jobs de Railway para tareas programadas. Multi-tenancy con **defensa en profundidad**: filtro por `clinic_id` en queries SQLAlchemy + PostgreSQL Row-Level Security como segunda capa en motor.
+**Patrón elegido:** Arquitectura de tres capas (Presentation / Application / Data) con orquestación async desacoplada (ARQ) para el pipeline de IA y un cron diario de Railway para los recordatorios. Multi-tenancy con **defensa en profundidad**: filtro por `clinic_id` en queries SQLAlchemy + PostgreSQL Row-Level Security como segunda capa en motor.
 
 **Justificación:**
-- **FastAPI + PostgreSQL** proveen un backend tipado, de alta performance y con soporte async nativo. La integración con Pydantic v2 hace que el schema de extracción de IA (`ClinicalRecordExtraction`) sirva simultáneamente como tool_use schema para Claude y como shape del JSONB en `clinical_records_ai`.
-- **Expo (Expo Router + Tamagui)** con build web vía React Native Web permite compartir la UI entre web y móvil (iOS/Android) desde el primer componente — el día que se libere la app móvil no hay un branch separado, sólo se agrega el target correspondiente al mismo monorepo.
-- **ARQ** desacopla el procesamiento de IA (latencia variable de 5–30s en Whisper) de la respuesta HTTP. Async-nativo, mismo Redis que ya se necesita para refresh tokens — sin agregar Celery (que arrastra worker pesado, mala compatibilidad async y operación compleja).
-- **PostgreSQL Row-Level Security** se habilita en todas las tablas con `clinic_id` como defensa de segundo nivel: si una query SQLAlchemy omite el filtro por `clinic_id`, el motor de DB devuelve cero filas en lugar de filtrar entre clínicas. La fuga de datos clínicos entre tenants se vuelve imposible a nivel de motor.
-- **Railway-solo** (todo en un proyecto) elimina la fricción operativa de dos clouds (Vercel + Railway): sin CORS, sin duplicación de envs, sin observabilidad fragmentada. Para un equipo de 2 founders, simplifica drásticamente el día a día.
+- **FastAPI + PostgreSQL** proveen un backend tipado, async-nativo y de alta performance. Pydantic v2 hace que el schema de extracción (`ClinicalRecordExtraction`) sirva simultáneamente como tool_use schema para Claude y como shape del JSONB en `clinical_records_ai`.
+- **Expo (Expo Router + Tamagui)** con build web vía React Native Web comparte la UI entre web y móvil desde el primer componente — las capas `services/` y `store/` se portan sin reescritura.
+- **ARQ** desacopla el pipeline de IA (latencia variable de Whisper + 2 llamadas a Claude) de la respuesta HTTP. Async-nativo, mismo Redis que ya se usa para refresh tokens — sin agregar Celery.
+- **PostgreSQL Row-Level Security** en cada tabla con `clinic_id`: si una query omite el filtro, el motor devuelve cero filas en lugar de filtrar entre clínicas. La fuga de datos clínicos entre tenants se vuelve imposible a nivel de motor.
+- **Railway-solo** elimina la fricción operativa de dos clouds (sin CORS, sin duplicación de envs).
 
-**Trade-offs:**
-- **Single-cloud:** atado a Railway. Mitigación: todo corre en Docker, migrar a otro proveedor es factible (la portabilidad del stack lo permite).
-- **ARQ es menos maduro que Celery:** menos plugins, menos documentación. Mitigación: para el alcance del MVP (1 worker, ~750 consultas/mes) ARQ alcanza sobradamente.
-- **RLS agrega complejidad de setup:** requiere dos usuarios de DB (`app_runtime` con RLS forzado, `app_admin` con `BYPASSRLS` para Alembic) y `SET LOCAL` por request. Mitigación: el costo se paga una sola vez en la dependencia FastAPI que abre la sesión; el resto del código no se entera.
-- **Soporte offline diferido a Fase 2:** las clínicas con internet inestable pueden tener una experiencia degradada. Mitigación: el MVP asume conectividad estable; la indicación visual de offline se evalúa para Fase 1.
+**Trade-offs y decisiones de implementación:**
+- **Groq Whisper en lugar de OpenAI `whisper-1`:** se adoptó Groq (`whisper-large-v3`, vía SDK de OpenAI con `base_url` override) por su capa gratuita sin tarjeta, suficiente para el desarrollo del MVP. Cambiar de proveedor es config.
+- **SMTP (`aiosmtplib`) en lugar de Resend:** se migró en US-004 para entregar a cualquier destinatario sin verificar dominio (App Password de Gmail en dev; SES/Mailgun/Brevo en prod). Config-only para cambiar de proveedor.
+- **RLS agrega complejidad de setup:** dos usuarios de DB (`app_runtime` con RLS forzado, `app_admin` con `BYPASSRLS` para Alembic) + `set_config('app.clinic_id', …, true)` por request (se usa `set_config`, no `SET LOCAL`, porque Postgres no acepta parámetros vinculados en `SET`).
+- **Soporte offline diferido a Fase 2:** el MVP asume conectividad estable.
 
 ### **2.2. Descripción de componentes principales:**
 
 | Componente | Tecnología | Responsabilidad |
 |---|---|---|
-| **Frontend SPA** | React 18 + TypeScript, Expo Router + Tamagui, Vite (web build), Zustand, TanStack Query, Tailwind CSS, shadcn/ui | Interfaz de usuario web + móvil compartida, gestión de estado local y de servidor, grabación de audio (MediaRecorder API en web / expo-av en nativo) |
-| **Frontend — agenda** | Schedule-X | Vista de agenda con drag & drop, vistas día/semana/mes, recursos por veterinario y detección de overlap |
-| **Frontend — data grids** | TanStack Table v8 + `@tanstack/react-virtual` | Listados densos (mascotas, vacunas próximas, historial) con sorting, filtering, paginación y virtualización |
-| **Backend API** | Python 3.12, FastAPI, Pydantic v2 | REST API con validación, autorización por rol (JWT), orquestación de servicios IA, generación de reportes |
-| **ORM / Migraciones** | SQLAlchemy 2.0 (async), Alembic | Acceso a base de datos tipado y async; migraciones versionadas. Las migraciones corren con `app_admin` (`BYPASSRLS`); las queries de la app corren con `app_runtime` (RLS forzado). |
-| **Worker asíncrono** | ARQ + Redis | Procesamiento del flujo IA (transcripción Whisper + estructuración Claude) sin bloquear la respuesta HTTP |
-| **Tareas programadas** | Cron de Railway | Recordatorios de turno (cada 15 min) y alertas de vacunación (diario), evitando un broker dedicado a notificaciones |
-| **Base de datos** | PostgreSQL 16 | Datos relacionales con multi-tenancy via `clinic_id` + **Row-Level Security** (defensa en profundidad), soft delete en entidades clínicas, JSONB para output estructurado de la IA, audit_log append-only |
-| **Object Storage** | Supabase Storage / AWS S3 | Almacenamiento de archivos adjuntos (imágenes, PDFs, audios) con URLs firmadas de acceso temporal (≤ 1h) |
-| **Whisper API** | OpenAI (`whisper-1`) | Transcripción de audio a texto; procesado de forma asíncrona via ARQ |
-| **Claude API** | Anthropic — modelo por subtarea: `claude-haiku-4-5` para inputs cortos, `claude-sonnet-4-6` para inputs largos o multimodales | **Estructuración** de la historia clínica via tool use + schema Pydantic `ClinicalRecordExtraction`. NO genera diagnósticos. Prompt caching activo (`cache_control: ephemeral`) desde el día 1. |
-| **Resend** | Resend | Envío de emails: recordatorios de turno y recuperación de contraseña (la activación del portal del cliente se incorpora en Fase 1.5) |
+| **Frontend** | React 18 + TypeScript, Expo Router + Tamagui, Zustand, TanStack Query, axios | UI web (y móvil compartida), estado local/servidor, grabación de audio (MediaRecorder web) |
+| **Frontend — agenda** | Schedule-X v2 | Vista día/semana, navegación por semana (anclada al lunes), filtro por veterinario, click en turno → reprogramar/cancelar |
+| **Frontend — data grids** | TanStack Table v8 | Listados (usuarios, clientes, mascotas) con orden y filtro |
+| **Backend API** | Python 3.12, FastAPI, Pydantic v2 | REST API con validación, RBAC por rol (JWT), orquestación de servicios IA |
+| **ORM / Migraciones** | SQLAlchemy 2.0 (async), Alembic | Acceso async tipado; migraciones `0001`–`0011`. Migraciones con `app_admin`; queries de la app con `app_runtime` (RLS forzado) |
+| **Worker asíncrono** | ARQ + Redis | Pipeline IA (Groq Whisper → Haiku cleanup → Sonnet extracción → audit en DB) sin bloquear la respuesta HTTP. Crea su propia sesión con `set_config` para RLS |
+| **Tarea programada** | Cron diario de Railway | `python -m app.jobs.send_appointment_reminders` (`0 8 * * *`); también invocable vía endpoint interno con API key |
+| **Base de datos** | PostgreSQL 16 | Multi-tenancy `clinic_id` + RLS, soft delete, JSONB para output IA, tablas append-only de auditoría |
+| **Object Storage** | Supabase Storage (Strategy `supabase`\|`s3`) | Adjuntos clínicos en bucket privado `clinical-attachments` con URLs firmadas (≤ 1h). Facade `StorageService` inyectable y mockeable |
+| **Transcripción** | Groq (`whisper-large-v3`) | Audio → texto, procesado de forma asíncrona vía ARQ |
+| **Estructuración IA** | Anthropic — `claude-haiku-4-5` (cleanup) + `claude-sonnet-4-6` (tool use + Vision a futuro) | Estructuración de la historia clínica vía tool use + schema Pydantic. Prompt caching (`cache_control: ephemeral`). No inventa diagnósticos |
+| **Email** | SMTP vía `aiosmtplib` | Recordatorios de turno y recuperación de contraseña (multipart texto+HTML, timeout 30s, fallos swalloweados anti-enumeración) |
 
 ### **2.3. Descripción de alto nivel del proyecto y estructura de ficheros**
 
-El proyecto sigue una organización monorepo con separación clara entre frontend y backend:
+Organización monorepo con separación frontend/backend:
 
 ```
 /
-├── frontend/                 # Expo + React Native Web SPA
+├── frontend/                 # Expo + React Native Web
 │   └── src/
-│       ├── app/              # Router global (Expo Router), providers
-│       ├── features/         # Módulos por dominio (feature-based)
-│       │   ├── auth/
-│       │   ├── clients/
-│       │   ├── pets/
-│       │   ├── clinical-records/
-│       │   ├── appointments/
-│       │   ├── vaccinations/
-│       │   ├── ai-assistant/
-│       │   ├── reports/
-│       │   ├── audit/        # Paneles de auditoría para Admin
-│       │   └── client-portal/   # Fase 1.5
-│       ├── shared/           # Componentes (Tamagui + shadcn/ui), hooks y utils reutilizables
-│       ├── services/         # Clientes HTTP por módulo (portables a iOS/Android sin cambios)
-│       └── store/            # Stores de Zustand (portables a iOS/Android sin cambios)
+│       ├── app/              # Router (Expo Router): (app) protegido, (auth), rutas públicas
+│       ├── features/         # Módulos por dominio (auth, users, clients, pets,
+│       │                     #   clinical-records, appointments, vaccinations,
+│       │                     #   ai-assistant, dashboard, …)
+│       ├── shared/           # Componentes Tamagui, hooks y utils reutilizables
+│       ├── services/         # Clientes HTTP por módulo (axios + interceptor JWT/refresh)
+│       └── store/            # Stores de Zustand (persist web/native)
 │
 ├── backend/                  # FastAPI application
 │   └── app/
-│       ├── core/             # Config, seguridad, dependencias (incluyendo SET LOCAL app.clinic_id)
-│       ├── api/v1/endpoints/ # Un archivo por módulo (auth, users, pets, ai, audit, etc.)
-│       ├── models/           # Modelos SQLAlchemy con AuditableMixin
-│       ├── schemas/          # Schemas Pydantic (request/response + ClinicalRecordExtraction)
+│       ├── core/             # Config, security, deps (set_config app.clinic_id para RLS)
+│       ├── api/v1/endpoints/ # auth, users, clients, pets, appointments,
+│       │                     #   clinical_records, vaccinations, search, ai,
+│       │                     #   reports, audit, internal
+│       ├── models/           # SQLAlchemy 2.0 con Timestamp/SoftDelete/Tenant mixins
+│       ├── schemas/          # Pydantic (request/response + ClinicalRecordExtraction)
 │       ├── crud/             # Operaciones de base de datos
-│       ├── services/         # Lógica de negocio (ai_service, notification_service, audit_logger)
-│       │   └── ai/           # AIProvider (strategy), AnthropicProvider, WhisperTranscriber, ModelSelector
-│       ├── worker/           # ARQ worker (settings + tasks async del flujo IA)
-│       │   └── tasks/ai.py   # transcribe_and_generate
-│       └── jobs/             # Scripts de cron de Railway
-│           ├── send_appointment_reminders.py  # cada 15 min
-│           └── notify_due_vaccinations.py     # diario, 08:00
+│       ├── services/         # ai_service, notification_service, audit_logger, storage
+│       ├── worker/           # ARQ worker (settings + tasks del pipeline IA)
+│       ├── jobs/             # send_appointment_reminders (cron diario)
+│       └── alembic/          # Migraciones 0001–0011
 │
-├── docs/                     # Documentación técnica completa
-│   ├── idea-inicial.md
-│   ├── prd.md
-│   ├── architecture.md
-│   ├── data-model.md
-│   ├── user-stories.md
-│   ├── info.md               # Profundización de cada herramienta del stack
-│   └── prompts/prompts.md    # Log cronológico de prompts por sesión
-│
-├── entrega1/                 # Esta entrega del curso
-│   ├── readme.md
-│   └── prompts.md
-│
-├── ia-agents/                # Agentes/skills/rules custom para asistencia de IA durante desarrollo
+├── e2e/                      # Playwright (auth, agenda, flujo IA)
+├── docs/                     # Documentación técnica + changelog/US-XXX.md + prompts
+├── entrega1/ · entrega2/     # Artefactos de las entregas del curso
+├── ia-agents/                # Agentes/skills/rules custom para asistencia de IA
 ├── docker-compose.yml        # Entorno de desarrollo local
 └── CLAUDE.md                 # Contexto del proyecto para asistentes de IA
 ```
 
-Patrón de arquitectura: **feature-based** en el frontend (cada módulo de dominio contiene sus componentes, hooks, types y lógica), **layered** en el backend (api → services → crud → models). Esta organización permite portabilidad a móvil sin reescritura: las capas `services/` y `store/` se comparten directamente entre web y móvil gracias a Expo.
+Patrón: **feature-based** en el frontend, **layered** en el backend (api → services/crud → models). Las capas `services/` y `store/` se comparten directamente entre web y móvil gracias a Expo.
 
 ### **2.4. Infraestructura y despliegue**
 
-Todos los servicios viven en un único proyecto de **Railway** para simplificar la operación, eliminar CORS interno y consolidar billing, logs y métricas en un solo dashboard.
+Todos los servicios se planifican en un único proyecto de **Railway**. El deploy está documentado (`backend/railway.cron.json` define el cron diario) pero aún no configurado; el desarrollo y la validación ocurren en local (Docker Compose).
 
 ```mermaid
 flowchart TD
-  GHA["GitHub Actions (CI/CD)<br/>lint → pytest → playwright → syrupy → build → deploy"]
+  GHA["GitHub Actions (CI)<br/>lint → pytest → typecheck (frontend)"]
   subgraph RAILWAY["Railway project (single)"]
     STATIC["Frontend (Static Site)"]
     BACKEND["Backend (Docker — FastAPI)"]
     WORKER["ARQ Worker (Docker)"]
-    CRON["Cron jobs"]
+    CRON["Cron diario (0 8 * * *)"]
     PG["PostgreSQL managed"]
     REDIS["Redis managed"]
   end
@@ -261,66 +263,49 @@ flowchart TD
   CRON --> PG
 ```
 
-*Figure 2: Pipeline de infraestructura y despliegue*
-
-| Servicio | Plataforma | Trigger |
-|---|---|---|
-| Frontend (Static Site) | Railway | Deploy automático desde rama `main` |
-| Backend (FastAPI) | Railway (Docker) | Deploy automático desde rama `main` |
-| ARQ Worker | Railway (Docker, mismo proyecto) | Deploy automático desde rama `main` |
-| Cron Jobs | Railway (cron schedules en panel) | Disparados según schedule (cada 15 min / diario) |
-| PostgreSQL | Railway managed | Gestionado por el proveedor |
-| Redis | Railway managed | Gestionado por el proveedor |
+*Figure 2: Pipeline de infraestructura y despliegue (planificado)*
 
 | Entorno | Branch | Propósito |
 |---|---|---|
-| Development | `dev` | Desarrollo local con Docker Compose |
-| Staging | `staging` | Validación antes de producción |
-| Production | `main` | Clínicas reales |
+| Development | `dev` | Desarrollo activo (Docker Compose local); 24 PRs `feat/us-XXX → dev` |
+| Production | `main` | Clínicas reales (deploy pendiente) |
 
-Las variables de entorno (API keys, DATABASE_URL, etc.) se configuran en el panel de Railway — nunca en el repositorio. Los secrets se rotan periódicamente.
+> **Nota sobre el flujo de git/board:** cada US se desarrolla en `feat/us-XXX` desde `dev`, con un commit por ticket (`feat(db|be|fe):`) y un PR a `dev` (`Closes #N`). El GitHub Project board recorre Todo → In Progress → In Review → Done. Como el PR apunta a `dev` (no a `main`), el `Closes #N` no auto-cierra al mergear a `dev`: el paso a Done es manual.
 
-**Costo estimado mensual (MVP de 3 clínicas piloto, ~750 consultas IA/mes):** ~U$ 55–70/mes (Railway $45 + Whisper $4.50 + Claude $2.50 con caching + S3 $2 + Resend free + dominio $1.25).
+**Costo estimado mensual (MVP de pocos usuarios):** ~U$ 55–70/mes en Railway-solo (la transcripción usa la capa gratuita de Groq; Claude con prompt caching es marginal a este volumen).
 
 ### **2.5. Seguridad**
 
-- **HTTPS obligatorio:** TLS gestionado por Railway en todos los servicios del proyecto (frontend estático, backend, worker).
-- **Autenticación JWT con refresh tokens:** Access token de corta duración firmado con HMAC; refresh tokens almacenados en Redis con rotación. Payload del JWT: `{ user_id, clinic_id, role: "admin"|"vet"|"reception", exp }`.
-- **Multi-tenancy con defensa en profundidad:** Filtro por `clinic_id` en cada query SQLAlchemy **+ PostgreSQL Row-Level Security**. La sesión SQLAlchemy ejecuta `SET LOCAL app.clinic_id = ...` al abrirse; las policies de cada tabla filtran por `current_setting('app.clinic_id')::uuid`. El usuario `app_runtime` que usa la API tiene `FORCE ROW LEVEL SECURITY`. **Suite de tests de aislamiento es bloqueante en CI.**
-- **Portal del cliente aislado** *(Fase 1.5)*: JWT separado con `client_id` autenticado contra tabla `clients`, no `users`. El middleware `ClientPortalAuth` bajo prefijo `/api/v1/client-portal/` es independiente.
-- **Headers de seguridad:** CSP, X-Frame-Options, HSTS configurados como middleware en FastAPI.
-- **Rate limiting:** En endpoints sensibles — login (5 req/min por IP), endpoints IA (10 req/min por clínica).
-- **Cifrado en reposo:** PostgreSQL con encryption at rest (Railway managed); S3/Supabase con cifrado de objetos.
-- **URLs de archivos firmadas:** Expiración máxima de 1 hora para archivos adjuntos.
-- **Soft delete:** Los registros clínicos nunca se eliminan físicamente; `deleted_at` para trazabilidad completa.
+- **HTTPS obligatorio** (TLS gestionado por Railway en prod).
+- **Autenticación JWT con refresh tokens:** access token de corta duración firmado con HMAC; refresh tokens en Redis con rotación. Payload: `{ user_id, clinic_id, role, exp }`. Índice inverso `user_refresh:{user_id}` para revocar todas las sesiones de un usuario al recuperar contraseña.
+- **Multi-tenancy con defensa en profundidad:** filtro por `clinic_id` en cada query **+ PostgreSQL Row-Level Security**. La sesión ejecuta `SELECT set_config('app.clinic_id', :cid, true)` al abrirse; las policies filtran por `current_setting('app.clinic_id')::uuid`. El usuario `app_runtime` tiene `FORCE ROW LEVEL SECURITY`.
+- **Anti-enumeración:** `forgot-password` siempre responde 200; login corre bcrypt contra un hash dummy si el usuario no existe (cierra el timing-oracle); accesos cruzados a recursos de otra clínica devuelven 404, no 403.
+- **Rate limiting / headers de seguridad:** planificados como middleware en FastAPI.
+- **Cifrado en reposo** (Postgres + Storage managed) y **URLs de archivos firmadas** (≤ 1h) para adjuntos.
+- **Soft delete:** los registros clínicos nunca se eliminan físicamente. Excepción: los turnos se cancelan como cambio de estado (`status='cancelled'` + `cancelled_at`/`cancelled_by`/`cancellation_reason`), no con `deleted_at`, para liberar el horario.
 - **Auditoría completa:**
-  - `audit_log` registra todas las mutaciones (CREATE/UPDATE/DELETE/RESTORE) sobre tablas tenant-scoped vía event listener de SQLAlchemy. Almacena `actor_id`, `actor_ip`, `actor_user_agent`, `entity_type`, `entity_id`, `changes` (JSONB con diff old/new), `request_id` para correlación.
+  - `audit_log` registra todas las mutaciones (create/update/delete/restore + acciones explícitas como `status_change`, `attachment_added`) sobre tablas tenant-scoped, vía event listener de SQLAlchemy `after_flush`. Diff old/new en JSONB.
   - `clinical_record_access_log` registra cada lectura individual de una historia clínica.
-  - **Append-only enforced en DB:** `REVOKE UPDATE, DELETE ON audit_log, clinical_record_access_log FROM app_runtime`. La integridad histórica no depende de la disciplina del developer.
-  - Retención de 7 años; anonimización (no borrado) ante derecho al olvido.
-  - Acceso restringido al rol `admin` bajo `/api/v1/audit/*`.
-- **Auditoría de IA:** Toda interacción con Whisper y Claude se almacena en `clinical_records_ai` (input original, transcripción, prompt completo, schema usado, output estructurado, modelo, cache hit/miss tokens, tiempo de procesamiento). Tabla append-only.
-- **Secrets:** Rotados periódicamente; nunca en código fuente.
+  - **Append-only enforced en DB:** `REVOKE UPDATE, DELETE … FROM app_runtime`.
+- **Auditoría de IA:** toda interacción con Whisper y Claude se almacena en `clinical_records_ai` (input, transcripción, prompt completo, schema, output estructurado, modelo, tokens de cache, tiempo). Tabla append-only.
 
 ### **2.6. Tests**
 
 | Tipo | Tecnología | Cobertura |
 |---|---|---|
-| **Unitarios + integración** | pytest + pytest-asyncio | ≥ 80% en `app/api/v1/`; ejecuta < 5 min |
-| **E2E del flujo crítico** | Playwright | Login → crear turno → grabar audio → ver historia clínica pre-completada → confirmar y guardar |
-| **Snapshot del prompt IA** | syrupy | Bloquea el merge cuando el system prompt o el schema enviado a Claude cambian sin actualizar el snapshot — detecta regresiones silenciosas en la calidad de la extracción |
-| **Aislamiento multi-tenant** | pytest (suite custom) | **Bloqueante en CI.** Crea dos clínicas con datos y verifica que ningún endpoint con JWT de la clínica A retorne filas de B; misma verificación entre dos clientes del portal en Fase 1.5 |
-| **Append-only de auditoría** | pytest | Verifica que un intento de `UPDATE` o `DELETE` sobre `audit_log` desde el rol `app_runtime` retorna error de permisos de Postgres |
-| **Frontend** | Vitest + React Native Testing Library | Componentes Tamagui + hooks de TanStack Query |
-| **Accesibilidad** | Lighthouse / axe-core | WCAG 2.1 nivel AA en formulario clínico, agenda, búsqueda |
-
-CI pipeline: `lint → pytest → playwright → syrupy → build → deploy a Railway`, completo en < 10 minutos desde el merge a `main`.
+| **Unitarios + integración (backend)** | pytest + pytest-asyncio (engine aiosqlite, rollback por test, `AsyncClient`) | Endpoints, CRUD, RLS, migraciones, append-only. Suite > 570 tests al cierre de US-010 |
+| **Snapshot del prompt IA** | syrupy | Bloquea el merge si el system prompt o el schema enviado a Claude cambian sin actualizar el snapshot |
+| **Aislamiento multi-tenant + append-only** | pytest (suite custom) | Verifica aislamiento entre clínicas y que `UPDATE`/`DELETE` sobre `audit_log` desde `app_runtime` falle con error de permisos de Postgres |
+| **Frontend** | Jest + React Native Testing Library (mock de Tamagui/Expo Router/Zustand/TanStack Query) | Componentes, hooks, formularios, máscaras de entrada. Suite > 400 tests |
+| **E2E del flujo crítico** | Playwright (chromium) | Registro, login (redirección por rol + persistencia), agenda (ver/togglear/filtrar/crear turno), flujo IA |
 
 ---
 
 ## 3. Modelo de Datos
 
 ### **3.1. Diagrama del modelo de datos:**
+
+Todas las entidades están implementadas vía migraciones Alembic `0001`–`0011`, con `clinic_id` + RLS forzada en las tablas tenant-scoped.
 
 ```mermaid
 erDiagram
@@ -346,13 +331,14 @@ erDiagram
     uuid id PK
     string name
     string plan
+    string timezone
     timestamptz created_at
   }
 
   USER {
     uuid id PK
     uuid clinic_id FK
-    string email "UNIQUE"
+    string email "UNIQUE per clinic"
     string password_hash
     string role "admin | vet | reception"
     string first_name
@@ -372,8 +358,6 @@ erDiagram
     text notes
     boolean portal_enabled "Fase 1.5"
     string password_hash "Fase 1.5"
-    boolean is_active "Fase 1.5"
-    timestamptz last_login_at "Fase 1.5"
     timestamptz deleted_at
   }
 
@@ -382,11 +366,12 @@ erDiagram
     uuid clinic_id FK
     uuid client_id FK
     string name
-    string species
+    string species "texto libre"
     string breed
     date birthdate
     string sex
     decimal weight_kg
+    boolean neutered
     text medical_notes
     timestamptz deleted_at
   }
@@ -397,7 +382,11 @@ erDiagram
     uuid pet_id FK
     uuid vet_id FK
     timestamptz scheduled_at
+    int duration_minutes
     string status "pending | attended | cancelled"
+    timestamptz cancelled_at
+    uuid cancelled_by
+    text cancellation_reason
     text notes
   }
 
@@ -406,7 +395,7 @@ erDiagram
     uuid appointment_id FK
     string channel "email"
     int trigger_hours_before
-    string status "sent | failed | undelivered"
+    string status "sent | failed"
     timestamptz sent_at
     text error_message
   }
@@ -419,8 +408,8 @@ erDiagram
     uuid created_by FK
     text consultation_reason
     text symptoms
-    text diagnosis "completado por el vet, no por la IA"
-    text treatment "completado por el vet, no por la IA"
+    text diagnosis "vet (manual o dictado a la IA)"
+    text treatment "vet (manual o dictado a la IA)"
     text medication
     decimal weight_kg
     decimal temperature_c
@@ -429,8 +418,9 @@ erDiagram
 
   CLINICAL_ATTACHMENT {
     uuid id PK
+    uuid clinic_id FK
     uuid clinical_record_id FK
-    text file_url
+    text file_url "storage key canónico"
     string file_name
     string file_type
     int file_size_bytes
@@ -439,14 +429,15 @@ erDiagram
 
   CLINICAL_RECORD_AI {
     uuid id PK
-    uuid clinical_record_id FK
-    string input_type "voice | image | text"
+    uuid clinic_id FK
+    uuid clinical_record_id FK "nullable"
+    string input_type "voice | upload | text"
     text raw_input_url
     text transcription
     text prompt_sent
-    string schema_version "ClinicalRecordExtraction.v1"
-    jsonb ai_structured_output "sin diagnosis/treatment"
-    string model_used "whisper-1 | claude-haiku-4-5 | claude-sonnet-4-6"
+    string schema_version
+    jsonb ai_structured_output
+    string model_used "whisper-large-v3 | claude-haiku-4-5 | claude-sonnet-4-6"
     int cache_hit_tokens
     int cache_write_tokens
     int processing_time_ms
@@ -456,7 +447,7 @@ erDiagram
     uuid id PK
     uuid clinic_id FK
     uuid pet_id FK
-    uuid clinical_record_id FK
+    uuid clinical_record_id FK "nullable"
     uuid administered_by FK
     string vaccine_name
     string batch_number
@@ -468,16 +459,13 @@ erDiagram
   AUDIT_LOG {
     uuid id PK
     uuid clinic_id FK
-    string actor_type "user | client | system | cron"
-    uuid actor_id
+    string table_name
+    uuid record_id
+    string action "create | update | delete | status_change | attachment_added"
+    uuid changed_by_user_id
     inet actor_ip
-    text actor_user_agent
-    string action "create | update | delete | restore"
-    string entity_type
-    uuid entity_id
     jsonb changes "diff old/new"
-    uuid request_id
-    timestamptz created_at
+    timestamptz changed_at
   }
 
   CLINICAL_RECORD_ACCESS_LOG {
@@ -492,466 +480,270 @@ erDiagram
   }
 ```
 
-*Figure 3: Diagrama ER del modelo de datos del MVP (Fase 1) + extensión Fase 1.5 (campos de Portal del Cliente en `clients`)*
+*Figure 3: Diagrama ER del modelo de datos del MVP implementado (Fase 1) + campos de Portal del Cliente en `clients` reservados para Fase 1.5*
 
 ### **3.2. Descripción de entidades principales:**
 
-**Convenciones globales:** UUID como PK en todos los modelos; `created_at` y `updated_at` en todas las tablas; soft delete con `deleted_at` en modelos clínicos y de negocio; `clinic_id` presente en todas las entidades para multi-tenancy (con RLS habilitado en cada tabla); montos en centavos (INTEGER) para evitar errores de punto flotante.
+**Convenciones globales:** UUID como PK; `created_at`/`updated_at` en todas las tablas; soft delete con `deleted_at` en modelos clínicos y de negocio (excepto `appointments`, que usa cambio de estado); `clinic_id` con RLS habilitado en cada tabla tenant-scoped.
 
-#### `clinics`
-Entidad raíz del multi-tenancy. Cada clínica es un tenant aislado.
-**Campos clave:** `id` (UUID, PK), `name` (NOT NULL), `plan` (`free`/`pro`/`clinic`), `created_at`.
+- **`clinics`** — entidad raíz del multi-tenancy. Incluye `timezone` (IANA) para localizar la hora de los recordatorios.
+- **`users`** — staff (Admin/Vet/Reception) con JWT propio; email único por clínica; `last_login_at`.
+- **`clients`** — dueños de mascotas. Los campos de Portal (`portal_enabled`, `password_hash`…) están reservados para Fase 1.5.
+- **`pets`** — pacientes; `species` es texto libre (selector con opción "Otro"); `neutered` boolean.
+- **`appointments`** — turnos; índice para detección de solapamiento; cancelación lógica (`status='cancelled'` + campos asociados) que libera el horario (`has_overlap` y el listado filtran `status != 'cancelled'`).
+- **`clinical_records`** — núcleo del sistema; soft delete; editable (auditado), una historia activa por turno (guard 409).
+- **`clinical_records_ai`** — auditoría append-only del pipeline IA (input, transcripción, prompt, schema, output, modelo, tokens de cache, tiempo).
+- **`clinical_attachments`** — adjuntos (tenant-scoped + RLS); `file_url` es la storage key canónica; la signed URL se resuelve por respuesta.
+- **`vaccinations`** — vacunas aplicadas con próxima fecha; vínculo opcional a una consulta.
+- **`appointment_notifications`** — sin `clinic_id` (aislamiento vía `appointment_id`); índice UNIQUE parcial `(appointment_id, trigger_hours_before) WHERE status='sent'` para idempotencia.
+- **`audit_log` / `clinical_record_access_log`** — append-only enforced en motor (`REVOKE UPDATE, DELETE`); retención 7 años + anonimización ante derecho al olvido.
 
-#### `users`
-Personal de la clínica (Admin, Veterinario, Recepcionista). Authn con JWT propio.
-**Campos clave:** `id` (UUID, PK), `clinic_id` (FK, NOT NULL), `email` (NOT NULL, UNIQUE), `password_hash` (bcrypt), `role` (NOT NULL).
-**Índices:** `(clinic_id)`, `(email)`.
-
-#### `clients`
-Dueños de mascotas. *El acceso opcional al portal de autogestión y los campos asociados se incorporan en Fase 1.5.*
-**Campos clave (Fase 1):** `id` (UUID, PK), `clinic_id` (FK, NOT NULL), `email` (NULL en Fase 1; pasa a NOT NULL al habilitar el portal en Fase 1.5).
-**Campos adicionales (Fase 1.5 — Portal del Cliente):** `portal_enabled` (DEFAULT false), `password_hash` (NULL hasta activación), `is_active` (DEFAULT true), `last_login_at`.
-**Nota:** El campo `notes` (notas internas de la clínica) no es visible desde el portal del cliente.
-**Índices:** `(clinic_id)`, `(clinic_id, last_name)`, `(clinic_id, email)`.
-
-#### `pets`
-Mascotas / pacientes. Cada mascota pertenece a un cliente y a una clínica.
-**Campos clave:** `id`, `clinic_id` (FK), `client_id` (FK), `name`, `species`, `breed`, `birthdate`, `weight_kg`, `deleted_at`.
-**Índices:** `(clinic_id)`, `(client_id)`, `(clinic_id, name)`.
-
-#### `appointments`
-Turnos. Cada turno se asocia a una mascota y a un veterinario específico.
-**Campos clave:** `id`, `clinic_id`, `pet_id`, `vet_id` (FK → users), `scheduled_at`, `status` (`pending`/`attended`/`cancelled`).
-**Constraint:** índice único parcial sobre `(vet_id, scheduled_at)` donde `status = 'pending'` para prevenir solapamientos.
-**Índices:** `(clinic_id, scheduled_at)`, `(vet_id, scheduled_at)`, `(pet_id)`, `(status)`.
-
-#### `clinical_records`
-Consultas médicas. Núcleo del sistema. Nunca se eliminan físicamente (soft delete).
-**Campos clave:** `id`, `pet_id` (FK), `appointment_id` (FK, NULL — puede ser consulta directa sin turno previo), `created_by` (FK → users), `consultation_reason` (NOT NULL), `symptoms`, `diagnosis`, `treatment`, `medication`, `weight_kg`, `temperature_c`, `deleted_at`.
-**Índices:** `(pet_id, created_at DESC)`, `(clinic_id)`.
-
-#### `clinical_records_ai`
-Auditoría completa del flujo de **estructuración** IA. Tabla append-only, no visible para el veterinario en la UI normal.
-**Campos clave:** `clinical_record_id` (FK), `input_type` (voice/image/text), `raw_input_url` (archivo original en S3), `transcription` (output de Whisper), `prompt_sent` (prompt completo + schema), `schema_version`, `ai_structured_output` (JSONB con los campos extraídos según schema Pydantic — **sin** `diagnosis` ni `treatment` en el MVP), `model_used` (whisper-1, claude-haiku-4-5 o claude-sonnet-4-6 según subtarea), `cache_hit_tokens`, `cache_write_tokens`, `processing_time_ms`.
-**Índices:** `(clinical_record_id)`, `(model_used, created_at)` para análisis de costo/calidad por modelo.
-
-#### `audit_log`
-Auditoría de mutaciones (CREATE/UPDATE/DELETE/RESTORE) sobre todas las tablas tenant-scoped. **Append-only enforced en DB** (`REVOKE UPDATE, DELETE` al rol `app_runtime`).
-**Campos clave:** `clinic_id` (con RLS), `actor_type` (`user`/`client`/`system`/`cron`), `actor_id`, `actor_ip`, `actor_user_agent`, `action`, `entity_type`, `entity_id`, `changes` (JSONB con diff old/new), `request_id`.
-**Índices:** `(clinic_id, entity_type, entity_id, created_at DESC)`, `(clinic_id, actor_id, created_at DESC)`.
-
-#### `clinical_record_access_log`
-Auditoría de lecturas individuales de historias clínicas (cumplimiento Ley 25.326). Append-only.
-**Campos clave:** `clinical_record_id` (FK), `actor_type`, `actor_id`, `actor_ip`, `access_type` (`view`/`export`/`print`).
-
-#### `vaccinations`, `clinical_attachments`, `appointment_notifications`
-Entidades complementarias. Detalle completo en [docs/data-model.md](../docs/data-model.md).
-
-> **Entidades de Fase 2** *(schema definido para no requerir cambios estructurales al implementarse):* `services` (servicios cobrables), `payments` (pagos contra servicios), `inventory_items` (stock de medicamentos).
+> **Entidades de Fase 2** (no implementadas): `services`, `payments`, `inventory_items`.
 
 ---
 
 ## 4. Especificación de la API
 
-Endpoints más representativos del flujo diferenciador del producto (asistencia IA para historias clínicas).
+Endpoints implementados (selección representativa). Todos requieren JWT con `clinic_id` salvo los públicos (`/auth/*`, landing de turno) y el interno (API key). Multi-tenancy reforzada con RLS.
+
+**Autenticación** — `POST /auth/register`, `POST /auth/login`, `POST /auth/refresh`, `POST /auth/logout`, `POST /auth/forgot-password`, `POST /auth/reset-password`.
+
+**Staff / Clientes / Mascotas** — `GET/POST/PATCH/DELETE /users`, `GET/POST/PUT/DELETE /clients`, `GET /pets`, `GET /pets/{id}` (perfil agregado), `POST /clients/{client_id}/pets`, `GET /search?q=`.
+
+**Agenda** — `GET /appointments?date=&view=day|week&vet_id=`, `POST /appointments` (409 por solapamiento), `PATCH /appointments/{id}` (reprogramar), `DELETE /appointments/{id}` (cancelar lógico), `PATCH /appointments/{id}/status` (marcar atendido), `GET /appointments/{id}/notifications`.
+
+**Historia clínica** — `GET /pets/{id}/clinical-records` (paginado), `POST /clinical-records`, `GET /clinical-records/{id}`, `PATCH /clinical-records/{id}`, `DELETE /clinical-records/{id}`, `GET /clinical-records/by-appointment/{appointment_id}`, `POST/GET /clinical-records/{id}/attachments`, `DELETE /clinical-records/{id}/attachments/{attachment_id}`.
+
+**Vacunación** — `POST/GET /pets/{pet_id}/vaccinations`.
+
+**Asistente IA** (flujo diferenciador):
 
 ```yaml
 openapi: 3.1.0
 info:
   title: Veterinary Intelligence Platform API
   version: v1
-  description: |
-    REST API multi-tenant para gestión clínica veterinaria con IA.
-    Todos los endpoints requieren JWT con `clinic_id` en el payload.
-    Multi-tenancy adicional reforzada con PostgreSQL Row-Level Security.
-servers:
-  - url: https://app.veterinaria.ar/api/v1
-    description: Production (Railway)
-
 paths:
-  /ai/transcribe:
+  /ai/transcribe-voice:
     post:
-      summary: Encolar transcripción de audio
+      summary: Encolar transcripción de una grabación de voz
       description: |
-        Recibe un archivo de audio, lo sube a S3 temporal y encola una tarea ARQ
-        que llamará a Whisper API. Retorna un task_id que el frontend usa para hacer polling.
+        Recibe el audio grabado, valida formato/tamaño (≤ 20 MB) y encola una tarea ARQ
+        (Groq Whisper → Claude Haiku cleanup → Claude Sonnet tool use). Retorna un task_id
+        para polling. Rol vet/admin.
       security: [{ bearerAuth: [] }]
-      requestBody:
-        required: true
-        content:
-          multipart/form-data:
-            schema:
-              type: object
-              properties:
-                audio:
-                  type: string
-                  format: binary
-                  description: Archivo MP3, MP4, WAV, M4A o WebM (máx. 20 MB)
-                pet_id:
-                  type: string
-                  format: uuid
-              required: [audio, pet_id]
       responses:
-        '202':
-          description: Tarea encolada
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  task_id: { type: string, format: uuid }
-                  status: { type: string, enum: [queued] }
-        '400': { description: Audio inválido o > 20 MB }
-        '401': { description: JWT inválido o ausente }
-        '403': { description: Rol distinto de `vet` o `admin` }
+        '202': { description: "Tarea encolada — { task_id, status: pending }" }
+        '413': { description: "Audio > 20 MB" }
+        '403': { description: "Rol distinto de vet o admin" }
 
-  /ai/extract-record:
+  /ai/transcribe-upload:
     post:
-      summary: Estructurar contenido en los campos de la historia clínica
+      summary: Subir un archivo de audio externo para pre-llenado IA
       description: |
-        Recibe la transcripción (o texto libre / descripción de imagen) y la estructura
-        en los campos predefinidos usando Claude con tool use + schema Pydantic
-        (`ClinicalRecordExtraction`). NO genera diagnósticos ni tratamientos sugeridos.
-        Prompt caching activo: el system prompt + schema se cachean entre llamadas.
+        Igual al pipeline de transcribe-voice pero acepta un archivo subido
+        (MP3/MP4/WAV/M4A/WebM/AAC; valida MIME con fallback a extensión).
+        input_type="upload" en clinical_records_ai.
       security: [{ bearerAuth: [] }]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                transcript: { type: string }
-                pet_id: { type: string, format: uuid }
-                input_type: { type: string, enum: [voice, image, text] }
-              required: [transcript, pet_id, input_type]
+      responses:
+        '202': { description: "Tarea encolada" }
+        '413': { description: "Archivo > 20 MB" }
+        '422': { description: "Formato no soportado / archivo vacío / pet_id inválido" }
+
+  /ai/tasks/{task_id}:
+    get:
+      summary: Polling del resultado del pipeline IA
+      security: [{ bearerAuth: [] }]
       responses:
         '200':
-          description: Campos extraídos
+          description: Estado de la tarea
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  extraction:
+                  status: { type: string, enum: [pending, completed, failed] }
+                  structured_output:
                     type: object
                     properties:
                       consultation_reason: { type: string, nullable: true }
                       symptoms: { type: string, nullable: true }
                       weight_kg: { type: number, nullable: true }
                       temperature_c: { type: number, nullable: true }
-                      medication_taken: { type: string, nullable: true }
-                      schema_version: { type: string, example: "v1" }
-                  diagnosis: { type: string, nullable: true, description: "Siempre null en MVP — completar manualmente" }
-                  treatment: { type: string, nullable: true, description: "Siempre null en MVP — completar manualmente" }
-                  ai_audit_id: { type: string, format: uuid, description: "ID en clinical_records_ai" }
+                      referred_medication: { type: string, nullable: true }
+                      diagnosis: { type: string, nullable: true, description: "Solo si el vet lo dicta explícitamente; nunca inventado" }
+                      treatment: { type: string, nullable: true, description: "Solo si el vet lo dicta explícitamente; nunca inventado" }
                   model_used: { type: string }
-                  cache_hit_tokens: { type: integer }
-        '422': { description: Output de Claude no cumple el schema Pydantic }
-        '504': { description: Timeout > 30s — fallback a entrada manual }
+                  error: { type: string, nullable: true }
 
   /clinical-records:
     post:
       summary: Crear historia clínica
       description: |
-        Persiste la historia clínica validada por el veterinario (luego de editar el pre-fill IA).
-        Inserción atómica en `clinical_records` + `clinical_records_ai`. Event listener de
-        SQLAlchemy registra automáticamente el insert en `audit_log`.
+        Persiste la historia validada por el veterinario. Si trae appointment_id y el turno
+        está 'pending', lo transiciona a 'attended' (idempotente). El listener de SQLAlchemy
+        registra el insert en audit_log automáticamente. 409 si el turno ya tiene historia activa.
       security: [{ bearerAuth: [] }]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                pet_id: { type: string, format: uuid }
-                appointment_id: { type: string, format: uuid, nullable: true }
-                consultation_reason: { type: string }
-                symptoms: { type: string }
-                diagnosis: { type: string }
-                treatment: { type: string }
-                medication: { type: string }
-                weight_kg: { type: number }
-                temperature_c: { type: number }
-                ai_audit_id: { type: string, format: uuid, nullable: true, description: "Vincula con clinical_records_ai si se usó IA" }
-              required: [pet_id, consultation_reason]
       responses:
         '201': { description: Creada }
-        '403': { description: Rol distinto de `vet` o `admin` }
+        '409': { description: "El turno ya tiene una historia clínica activa" }
+        '403': { description: "Rol distinto de vet o admin" }
 
 components:
   securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
+    bearerAuth: { type: http, scheme: bearer, bearerFormat: JWT }
 ```
 
 ---
 
 ## 5. Historias de Usuario
 
-**Historia de Usuario 1 — Historia Clínica Asistida por IA (US-013)**
+**Historia de Usuario 1 — Historia Clínica Asistida por IA (US-013, implementada)**
 
 Como Veterinario, quiero grabar una nota de voz durante o después de la consulta y que la app **complete los campos predefinidos de la historia clínica** a partir de lo dictado, para reducir el tiempo de escritura administrativa.
 
-**Criterios de aceptación:**
-- Puedo iniciar y detener la grabación desde la app (sin aplicación externa)
-- Veo un indicador de estado de carga mientras se procesa el audio
-- Recibo los campos pre-completados con la información extraída del audio: motivo de consulta, síntomas, peso, temperatura, medicación referida
-- Los campos `diagnóstico` y `tratamiento` quedan **vacíos** para que yo los complete — la IA no genera diagnósticos ni sugerencias terapéuticas en esta etapa
-- La UI muestra explícitamente el alcance: "El asistente completa los campos a partir de lo dictado. No sugiere diagnósticos ni tratamientos"
-- Puedo editar cualquier campo antes de guardar
-- Si el procesamiento falla (timeout > 30s), puedo completar el formulario manualmente sin perder lo ingresado
-- El registro queda guardado junto con el audio original y la extracción IA para auditoría
+**Criterios de aceptación (verificados):**
+- Inicio/detengo la grabación desde la app (MediaRecorder web); veo un indicador de procesamiento.
+- Recibo pre-completados: motivo, síntomas, peso, temperatura y medicación referida.
+- Diagnóstico y tratamiento se completan **solo si los dicté explícitamente**; la IA nunca los inventa (se distingue `referred_medication` —lo que el dueño ya dio— de `treatment` —lo que indica el vet—).
+- Puedo editar cualquier campo antes de guardar; si el procesamiento falla (timeout > 30s) completo el formulario manualmente.
+- El registro y la interacción IA quedan auditados en `clinical_records_ai`.
 
 ---
 
-**Historia de Usuario 2 — Agenda multi-veterinario sin solapamientos (US-017)**
+**Historia de Usuario 2 — Agenda multi-veterinario sin solapamientos (US-017/018/019, implementada)**
 
-Como Recepcionista o Veterinario, quiero crear un turno asignado a una mascota y un veterinario específico, para organizar la agenda de la clínica sin solapamientos.
+Como Recepcionista o Veterinario, quiero crear, reprogramar y cancelar turnos asignados a una mascota y un veterinario, para organizar la agenda sin solapamientos.
 
-**Criterios de aceptación:**
-- Debo seleccionar: mascota (con búsqueda por nombre), veterinario, fecha, hora y motivo
-- El sistema detecta solapamiento: si el veterinario ya tiene un turno en ese horario, muestra error claro con el horario conflictivo (HTTP 409)
-- El turno creado queda en estado "Pendiente" y aparece inmediatamente en la agenda (Schedule-X)
-- Se genera automáticamente una notificación de recordatorio por email para el dueño (48h y 24h antes), disparada por el cron `send_appointment_reminders.py` que corre cada 15 min
+**Criterios de aceptación (verificados):**
+- Selecciono mascota (búsqueda por nombre), veterinario, fecha y hora; el sistema detecta solapamiento (HTTP 409).
+- El turno aparece en la agenda Schedule-X (día/semana, filtrable por vet, en español, anclada al lunes).
+- Click en un turno pendiente abre reprogramar (re-valida disponibilidad) o cancelar (motivo opcional). La cancelación libera el horario (re-bookeable).
 
 ---
 
-**Historia de Usuario 3 — Auditoría de cambios en historia clínica (US-039)**
+**Historia de Usuario 3 — Adjuntar imágenes y archivos a una consulta (US-010, implementada)**
 
-Como Administrador, quiero ver el historial completo de cambios sobre una historia clínica, para entender quién modificó qué y cuándo ante cualquier consulta o reclamo.
+Como Veterinario, quiero adjuntar imágenes o PDFs a una consulta y verlos al reabrirla, para documentar estudios y evidencias.
 
-**Criterios de aceptación:**
-- Accedo desde el detalle de la historia clínica a un panel "Historial de cambios"
-- Cada entrada muestra: timestamp, quién (nombre + rol), acción (create/update/delete), y para updates el diff campo por campo (valor anterior → valor nuevo)
-- Puedo filtrar por usuario y por rango de fechas
-- Los usuarios `vet` y `reception` no ven este panel; el endpoint subyacente (`GET /api/v1/audit/clinical-records/{id}`) retorna HTTP 403
-- Los datos vienen de `audit_log`, que es append-only enforced en DB — ningún registro de cambio puede ser modificado o eliminado
+**Criterios de aceptación (verificados):**
+- Adjunto archivos (JPEG/PNG/PDF, ≤ 20 MB, máx. 10); el lote se valida completo antes de subir nada (sin archivos huérfanos).
+- Los archivos se almacenan en Supabase Storage (bucket privado) y se sirven con URL firmada de corta vida.
+- Al reabrir la consulta veo la grilla de miniaturas; al hacer click se abre el archivo en una pestaña nueva. Borrado por adjunto (soft delete auditado).
 
 ---
 
 ## 6. Tickets de Trabajo
 
-> Documenta 3 de los tickets de trabajo principales del desarrollo, uno de backend, uno de frontend, y uno de bases de datos. Da todo el detalle requerido para desarrollar la tarea de inicio a fin teniendo en cuenta las buenas prácticas al respecto.
-
-Los tres tickets seleccionados cubren el flujo diferenciador del MVP: la historia clínica asistida por IA. Son los más representativos de la arquitectura del sistema, abarcan las tres capas solicitadas (backend, frontend, base de datos) y sus criterios de aceptación son verificables de forma autónoma por un agente de IA.
+Tres tickets representativos del MVP implementado (backend, frontend y base de datos), con sus commits reales sobre `dev`.
 
 ---
 
-### Ticket 1 — Backend · `US-013-BE` · Talla: M
+### Ticket 1 — Backend · `US-013-BE` (#323) · Talla: M · commit `5a4a45e`
 
 **Título:** Endpoint de transcripción de voz con pipeline IA asíncrono
 
-**Historia de usuario:** Como Veterinario, quiero grabar una nota de voz durante o después de la consulta y que la app complete automáticamente los campos de la historia clínica con lo que dicté, para reducir el tiempo de escritura administrativa.
+**Descripción técnica:** `POST /ai/transcribe-voice` recibe el audio, valida formato/tamaño y encola una tarea ARQ devolviendo `{ task_id, status: "pending" }` (202); el resultado se recupera con `GET /ai/tasks/{task_id}`. La tarea ARQ ejecuta, en secuencia: (1) transcripción con **Groq Whisper `whisper-large-v3`** (SDK de OpenAI con `base_url` override); (2) limpieza con **`claude-haiku-4-5`**; (3) extracción estructurada con **`claude-sonnet-4-6`** (tool use + schema Pydantic `ClinicalRecordExtraction`, `cache_control: ephemeral`); (4) auditoría: inserta una fila en `clinical_records_ai`. El worker crea su propia sesión con `set_config('app.clinic_id', …, true)` para respetar RLS sin contexto JWT.
 
-**Descripción técnica:**
-
-Implementar `POST /ai/transcribe-voice` que recibe el archivo de audio grabado desde el frontend, lo sube a S3/Supabase Storage como archivo temporal y encola una tarea ARQ devolviendo `{"task_id": "<uuid>", "status": "pending"}` (HTTP 202). El resultado se recupera con `GET /ai/tasks/{task_id}`.
-
-La tarea ARQ ejecuta el siguiente pipeline en secuencia:
-
-1. **Transcripción:** llama a Whisper API (`whisper-1`) con el audio recuperado de S3.
-2. **Limpieza:** pasa la transcripción a `claude-haiku-4-5` para normalizar abreviaciones y corregir errores tipográficos.
-3. **Extracción estructurada:** invoca Claude (`claude-sonnet-4-6`) con tool use + schema Pydantic `ClinicalRecordExtraction`. El system prompt tiene `cache_control: {"type": "ephemeral"}` para activar prompt caching. El schema tiene los campos `reason`, `symptoms`, `weight`, `temperature`, `referred_medication` como `Optional[str]`; los campos `diagnosis` y `treatment` son siempre `None` (nunca se populan en el MVP).
-4. **Auditoría:** inserta una fila en `clinical_records_ai` con `input_type`, `transcription`, `full_prompt`, `schema_used`, `structured_output`, `model`, `cache_hit`, `cache_tokens_read`, `processing_time_ms`, `status`.
-
-Timeout de 30 s: si el pipeline supera ese límite, el task retorna `status: "failed"`. El archivo temporal en S3 se elimina tras el procesamiento (exitoso o fallido).
-
-**Stack involucrado:** FastAPI · ARQ + Redis · Whisper API (`whisper-1`) · Claude API (`claude-haiku-4-5` + `claude-sonnet-4-6`) · Pydantic v2 · Supabase Storage / S3 · pytest + syrupy
+**Stack:** FastAPI · ARQ + Redis · Groq Whisper · Claude (haiku-4-5 + sonnet-4-6) · Pydantic v2 · pytest + syrupy.
 
 **Criterios de aceptación (BDD):**
+- *Happy path:* vet/admin envía audio válido → 202 + task_id; `GET /ai/tasks/{id}` → `status: "completed"` con los campos extraídos; fila en `clinical_records_ai`.
+- *Audio sin datos clínicos:* `completed` con campos `null`/vacíos; sin excepción; output vacío auditado.
+- *Timeout (> 30s):* `status: "failed"` con mensaje de fallback manual; sin reintento automático.
 
-*Escenario 1 — Happy path:*
-- **Dado que** el veterinario autenticado (rol `vet` o `admin`) envía `POST /ai/transcribe-voice` con un audio válido (WebM, WAV, M4A, MP3, MP4, ≤ 20 MB)
-- **Cuando** el endpoint encola la tarea ARQ y el worker la procesa en menos de 30 s
-- **Entonces** `POST` responde HTTP 202 con `{"task_id": "<uuid>", "status": "pending"}`; al consultar `GET /ai/tasks/{task_id}` el sistema devuelve `status: "completed"` con `structured_output` conteniendo `reason`, `symptoms`, `weight`, `temperature`, `referred_medication` extraídos del audio, y `diagnosis` y `treatment` como `null`; la tabla `clinical_records_ai` contiene una fila con todos los campos de auditoría
+**Notas de implementación reales:** se requirió subir el SDK de `anthropic==0.34.2` a `0.111.0` y corregir los model IDs (`claude-haiku-4-5-20251001`, `claude-sonnet-4-6`); se pasó `api_key` explícito al cliente Anthropic porque el worker no heredaba el entorno. El prompt se ajustó para extraer diagnosis/treatment cuando el vet los dicta (sin forzarlos a `None`).
 
-*Escenario 2 — Audio sin datos clínicos reconocibles:*
-- **Dado que** el audio contiene solo ruido o contenido sin información clínica estructurable
-- **Cuando** el worker procesa la transcripción con Claude tool use
-- **Entonces** el task devuelve `status: "completed"` con todos los campos clínicos como `null` o cadenas vacías; no se lanza excepción; `clinical_records_ai` registra el output vacío con el prompt y modelo usados
-
-*Escenario 3 — Timeout del worker (> 30 s):*
-- **Dado que** el procesamiento del audio supera el límite de 30 s
-- **Cuando** el cliente consulta `GET /ai/tasks/{task_id}`
-- **Entonces** el sistema devuelve `status: "failed"` con `error: "Processing timeout — please fill the form manually"`; la tarea no reintenta automáticamente; `clinical_records_ai` registra `status: "timeout"` con el tiempo transcurrido
-
-**INVEST:** I✅ N✅ V✅ E✅ S✅ T✅
-
-**Estimación y justificación (M):** Complejidad moderada por el pipeline de 3 pasos (Whisper → haiku → sonnet), la lógica de timeout en ARQ y el setup del prompt caching. Sin incertidumbre técnica mayor — todos los componentes están definidos; la integración es punto por punto. Estimado 3–4 días.
-
-**Dependencias:** US-013-DB (tabla `clinical_records_ai` debe existir para el paso de auditoría) · US-013-AI (schema `ClinicalRecordExtraction` y prompt del sistema)
+**INVEST:** I✅ N✅ V✅ E✅ S✅ T✅ · Dependencias: US-013-DB (#325), US-013-AI (#326).
 
 ---
 
-### Ticket 2 — Frontend · `US-013-FE` · Talla: M
+### Ticket 2 — Frontend · `US-013-FE` (#324) · Talla: M · commit `39d5ea9`
 
-**Título:** Grabación de voz en app con polling y pre-llenado de campos clínicos
+**Título:** Grabación de voz con polling y pre-llenado de campos clínicos
 
-**Historia de usuario:** Como Veterinario, quiero grabar una nota de voz durante o después de la consulta y que la app complete automáticamente los campos de la historia clínica con lo que dicté, para reducir el tiempo de escritura administrativa.
+**Descripción técnica:** dentro de `frontend/src/features/ai-assistant/`: `VoiceRecorder.tsx` (MediaRecorder web-only con `Platform.OS` guard, estados grabar/detener/procesando, spinner, disclaimer y error con fallback); `useVoiceTranscription.ts` (hook con polling cada 2s, timeout 30s y mapeo de los 6 campos al formulario); integración en `ClinicalRecordFormModal.tsx` (solo modo create). Validación con Zod antes de `POST /clinical-records`.
 
-**Descripción técnica:**
-
-Implementar dos componentes y un hook custom dentro de `frontend/src/features/ai-assistant/`:
-
-**`VoiceRecorder`** — componente que abstrae la grabación de audio en web (MediaRecorder API) y en nativo (expo-av), con estados `idle → recording → processing → done | error`. Expone `onAudioReady(blob: Blob)` que el padre llama al detener la grabación.
-
-**`useAIPolling(taskId: string)`** — hook TanStack Query que hace polling a `GET /ai/tasks/{task_id}` cada 2 s, se detiene al recibir `status: "completed"` o `status: "failed"`, y dispara un fallback automático a los 35 s. Devuelve `{ data, isLoading, isError, timedOut }`.
-
-**`ClinicalRecordForm`** — formulario existente (o nuevo si aún no existe) que consume el resultado del hook para pre-llenar los 5 campos clínicos (`reason`, `symptoms`, `weight`, `temperature`, `referred_medication`). Los campos `diagnosis` y `treatment` no se pre-llenan. Todos los campos son editables antes de guardar. Muestra el disclaimer: *"El asistente completa los campos a partir de lo dictado. No sugiere diagnósticos ni tratamientos."* visible en todo momento mientras hay un resultado IA activo.
-
-Validación de los campos con Zod antes de enviar el formulario a `POST /clinical-records`. Si el polling retorna `timedOut: true` o `isError: true`, muestra el mensaje de fallback y habilita la entrada manual completa.
-
-**Stack involucrado:** Expo Router · Tamagui · TanStack Query · Zustand · Zod · MediaRecorder API (web) / expo-av (nativo)
+**Stack:** Expo Router · Tamagui (tokens Clinical Serenity) · TanStack Query · Zustand · Zod · MediaRecorder.
 
 **Criterios de aceptación (BDD):**
+- *Happy path:* grabar → detener → `completed` < 30s → se pre-llenan motivo/síntomas/peso/temperatura/medicación (y diagnóstico/tratamiento si fueron dictados); disclaimer visible; todo editable.
+- *Extracción parcial:* los campos no extraídos quedan con placeholder vacío (no "null"), completables sin marcar error.
+- *Timeout/error:* mensaje de fallback y formulario habilitado para entrada manual; botón de grabación disponible para reintentar.
 
-*Escenario 1 — Happy path:*
-- **Dado que** el veterinario pulsa "Grabar", dicta la nota clínica y pulsa "Detener"
-- **Cuando** el audio se envía a `POST /ai/transcribe-voice` y el polling recibe `status: "completed"` dentro de los 30 s
-- **Entonces** los campos `motivo`, `síntomas`, `peso`, `temperatura` y `medicación referida` se pre-llenan con el output estructurado; los campos `diagnóstico` y `tratamiento` permanecen vacíos; el disclaimer es visible; todos los campos son editables antes de guardar
+**Notas reales:** durante el testing se corrigieron warnings de props de accesibilidad filtradas al DOM (`accessibilityRole`/`accessibilityState` solo-native) y la invalidación de queries al guardar (`useCreateClinicalRecord` ahora invalida también `["appointments"]` y la consulta por turno).
 
-*Escenario 2 — Campos parcialmente extraídos:*
-- **Dado que** el audio contiene solo motivo y síntomas sin peso ni temperatura
-- **Cuando** el polling recibe el resultado
-- **Entonces** los campos `peso` y `temperatura` muestran su placeholder vacío (no "null"); el veterinario puede completarlos manualmente sin que el formulario los marque como error requerido
-
-*Escenario 3 — Timeout o error de procesamiento:*
-- **Dado que** el polling supera los 35 s o recibe `status: "failed"`
-- **Cuando** el componente detecta el fallo
-- **Entonces** se muestra el mensaje "No se pudo procesar el audio. Podés completar el formulario manualmente." y el formulario queda habilitado para entrada manual sin datos pre-llenados; el botón de grabación queda disponible para reintentar
-
-**INVEST:** I✅ N✅ V✅ E✅ S✅ T✅
-
-**Estimación y justificación (M):** Complejidad moderada por la abstracción MediaRecorder/expo-av (comportamientos distintos en web y nativo) y la lógica del hook de polling con estados diferenciados (loading / completed / failed / timedOut). El formulario clínico en sí es straightforward. Estimado 3–4 días.
-
-**Dependencias:** US-013-BE (endpoint `POST /ai/transcribe-voice` y `GET /ai/tasks/{task_id}` disponibles o mockeados)
+**INVEST:** I✅ N✅ V✅ E✅ S✅ T✅ · Dependencias: US-013-BE.
 
 ---
 
-### Ticket 3 — Base de datos · `US-039-DB` · Talla: M
+### Ticket 3 — Base de datos · `US-009-DB` (dentro de #315) · Talla: M · commit `9b9ed5f`
 
 **Título:** Tabla `audit_log` append-only con REVOKE y listener SQLAlchemy automático
 
-**Historia de usuario:** Como Administrador, quiero ver el historial completo de cambios sobre una historia clínica, para entender quién modificó qué y cuándo ante cualquier consulta o reclamo.
+**Descripción técnica:** migración `0005_clinical_records_and_audit_log.py` que crea `clinical_records` y `audit_log` (índices + RLS forzada + grants, incluyendo `REVOKE UPDATE, DELETE ON audit_log FROM app_runtime`) y registra el listener genérico `setup_audit_listener` (`after_flush`, anti-recursión, snapshot en `create` / diff en `update`). El listener es transparente: ningún endpoint lo llama explícitamente. Acciones específicas (`status_change`, `attachment_added`) se anotan suprimiendo la fila genérica vía `session.info["audit_skip"]`.
 
-**Descripción técnica:**
-
-Crear la migración Alembic `003_audit_log.py` que establece la tabla `audit_log` y su infraestructura de seguridad:
-
-**Schema de la tabla:**
-```sql
-CREATE TABLE audit_log (
-    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    clinic_id   UUID NOT NULL REFERENCES clinics(id),
-    table_name  TEXT NOT NULL,
-    record_id   UUID NOT NULL,
-    action      TEXT NOT NULL CHECK (action IN ('create','update','delete','soft_delete')),
-    changed_by_user_id UUID REFERENCES users(id),
-    changes     JSONB,           -- {"field": {"before": ..., "after": ...}}
-    changed_at  TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-```
-
-**Append-only enforced en motor:**
-```sql
-REVOKE UPDATE, DELETE ON audit_log FROM app_runtime;
-```
-El rol `app_runtime` (usado por la API en producción) solo puede INSERT. Ningún código de aplicación — ni un bug, ni una vulnerabilidad — puede modificar o eliminar un registro de auditoría.
-
-**Índices para queries de auditoría:**
-```sql
-CREATE INDEX ix_audit_log_record
-    ON audit_log (clinic_id, table_name, record_id, changed_at DESC);
-CREATE INDEX ix_audit_log_user
-    ON audit_log (clinic_id, changed_by_user_id, changed_at DESC);
-```
-
-**Listener SQLAlchemy (`backend/app/services/audit_logger.py`):**
-
-```python
-from sqlalchemy import event
-from sqlalchemy.orm import Session
-
-AUDITED_MODELS = {ClinicalRecord, Appointment, Pet, Client, User, Vaccination}
-
-@event.listens_for(Session, "after_flush")
-def auto_audit(session: Session, flush_context):
-    for obj in (*session.new, *session.dirty, *session.deleted):
-        if type(obj) not in AUDITED_MODELS:
-            continue
-        action = _detect_action(obj, session)
-        changes = _build_diff(obj, session)
-        session.execute(
-            insert(AuditLog).values(
-                clinic_id=obj.clinic_id,
-                table_name=obj.__tablename__,
-                record_id=obj.id,
-                action=action,
-                changed_by_user_id=get_current_user_id(),
-                changes=changes,
-            )
-        )
-```
-
-El listener es transparente para el resto del código: ningún endpoint necesita llamarlo explícitamente.
-
-**Política de retención:** 7 años. La purga de registros vencidos solo puede ejecutarla el rol `app_admin` (con `BYPASSRLS`), mediante script documentado en `backend/scripts/purge_audit_log.py`.
-
-**Stack involucrado:** PostgreSQL 16 · Alembic · SQLAlchemy 2.0 (async) · pytest (tests de append-only y aislamiento)
+**Stack:** PostgreSQL 16 · Alembic · SQLAlchemy 2.0 async · pytest.
 
 **Criterios de aceptación (BDD):**
+- *Mutación auditada:* al hacer flush de un update sobre `clinical_records`, se inserta una fila en `audit_log` con `table_name`, `record_id`, `action`, `changed_by_user_id` y diff JSONB; sin llamada explícita.
+- *Append-only garantizado:* `UPDATE`/`DELETE` sobre `audit_log` desde `app_runtime` → `permission denied`; test bloqueante.
+- *Rendimiento:* las queries de auditoría usan índice compuesto.
 
-*Escenario 1 — Happy path (mutación registrada automáticamente):*
-- **Dado que** el listener SQLAlchemy está activo y el rol `app_runtime` actualiza una historia clínica (PATCH `/clinical-records/{id}`)
-- **Cuando** la sesión hace flush
-- **Entonces** se inserta automáticamente una fila en `audit_log` con `table_name: "clinical_records"`, el `record_id` correcto, `action: "update"`, el `changed_by_user_id` del contexto de sesión y el diff campo por campo en el JSONB `changes`; ningún endpoint necesita llamar explícitamente al listener
+**Notas reales:** durante el QA se detectó que `audit_log.actor_ip` estaba tipado `String(45)` en el modelo pero la migración lo crea como `INET` en Postgres → toda escritura tenant-scoped daba 500 (no detectado por SQLite); fix: `INET().with_variant(String(45), "sqlite")` (commit `3e9ddd1`).
 
-*Escenario 2 — Append-only garantizado:*
-- **Dado que** existen filas en `audit_log` y el rol en uso es `app_runtime`
-- **Cuando** se ejecuta `UPDATE audit_log SET action = 'x' WHERE id = :id` o `DELETE FROM audit_log WHERE id = :id`
-- **Entonces** PostgreSQL lanza `ERROR: permission denied for table audit_log` y la operación se revierte; la fila original permanece intacta; este test es bloqueante en CI
-
-*Escenario 3 — Query usa índice compuesto (rendimiento):*
-- **Dado que** `audit_log` tiene 100.000 filas distribuidas entre múltiples clínicas
-- **Cuando** se ejecuta `GET /api/v1/audit/clinical-records/{id}/mutations` con filtros de fecha
-- **Entonces** el query plan muestra `Index Scan` sobre `ix_audit_log_record` y la latencia del endpoint es < 200 ms en el percentil 95
-
-**INVEST:** I✅ N✅ V✅ E✅ S✅ T✅
-
-**Estimación y justificación (M):** Complejidad moderada por tres razones: (1) el REVOKE requiere configuración de dos roles Postgres (`app_runtime` / `app_admin`) coordinada con la migración de RLS de US-001-DB; (2) el listener SQLAlchemy necesita detectar correctamente `new` / `dirty` / `deleted` y construir el diff de forma genérica para todos los modelos auditables; (3) los tests de append-only deben verificar el comportamiento directamente en el motor Postgres, no solo en la capa ORM. Estimado 3–4 días.
-
-**Dependencias:** US-001-DB (roles `app_runtime` y `app_admin` deben existir en la BD) · `AuditableMixin` en los modelos SQLAlchemy
+**INVEST:** I✅ N✅ V✅ E✅ S✅ T✅ · Dependencias: roles `app_runtime`/`app_admin` (US-001-DB).
 
 ---
 
 ## 7. Pull Requests
 
-> El proyecto se encuentra en fase de documentación técnica. Las PRs documentadas a continuación corresponden a la rama `docs` donde vive toda la documentación de esta entrega. Las PRs de scaffolding de código (backend, frontend) están planificadas para iniciarse al cerrar Fase 1.
+El desarrollo del MVP se hizo con un PR por User Story sobre la rama `dev` (24 PRs, `feat/us-XXX → dev`, un commit por ticket). A continuación, tres PRs representativos del flujo diferenciador; la lista completa está debajo.
 
-**Pull Request 1 — Documentación técnica inicial (commit `cdc103f`)**
+**Pull Request 1 — US-013 Asistente IA: voz → campos clínicos (PR #415)**
 
-- **Branch:** `docs` → `main` *(pendiente de mergear; se mantiene en docs hasta validación con tutores)*
-- **Commit:** `cdc103f docs: add technical documentation and project structure`
-- **Contenido:** Setup inicial del repo. Creación de `docs/` con `idea-inicial.md` (concepto + roles + stack), `prd.md` (PRD completo de 15 secciones con 9 diagramas Mermaid), `architecture.md` (stack, estructura, infra, flujo IA), `data-model.md` (ERD + tablas), `user-stories.md` (historias por módulo).
-- **Cambios:** +5500 líneas de documentación.
+- **Branch:** `feat/us-013` → `dev` *(mergeado, commit `60fdf33`)*
+- **Contenido:** pipeline IA completo end-to-end. DB (`0011_clinical_records_ai` append-only), AI (schema `ClinicalRecordExtraction` + system prompt + snapshots syrupy), BE (`POST /ai/transcribe-voice`, `GET /ai/tasks/{id}`, tarea ARQ Groq Whisper → Haiku → Sonnet), FE (`VoiceRecorder` + `useVoiceTranscription` + integración al modal). Incluye el ajuste del prompt para extraer diagnóstico/tratamiento cuando el vet los dicta.
 
-**Pull Request 2 — Portal del cliente + entrega1 + ia-agents (commit `2dd272d`)**
+**Pull Request 2 — US-018 Agenda diaria/semanal (PR #396)**
 
-- **Branch:** `docs` → `main` *(pendiente)*
-- **Commit:** `2dd272d docs: add client portal, entrega1 artifacts and ia-agents`
-- **Contenido:** Incorporación del Portal del Cliente al modelo (luego diferido a Fase 1.5), creación de los artefactos de esta entrega (`entrega1/readme.md`, `entrega1/prompts.md`) y de la carpeta `ia-agents/` con agentes/skills/rules custom para asistencia de IA durante el desarrollo.
+- **Branch:** `feat/us-018` → `dev` *(mergeado, commit `752a28a`)*
+- **Contenido:** `GET /appointments?date=&view=&vet_id=` (sin N+1) + pantalla `(app)/agenda.tsx` con Schedule-X v2 (español, navegación por semana anclada al lunes, filtro por vet, botón "Nuevo turno"). Integra la búsqueda global como selector de mascota. Incluye `frontend/.npmrc` (`legacy-peer-deps=true`) para resolver el ERESOLVE de `@schedule-x/react` en CI.
 
-**Pull Request 3 — Revisión arquitectónica para alcance MVP + estándares 2026 (commit `aeeacff`)**
+**Pull Request 3 — US-010 Adjuntos clínicos (PR #414)**
 
-- **Branch:** `docs` → `main` *(pendiente)*
-- **Commit:** `aeeacff docs: revise architecture for MVP scope and 2026 standards`
-- **Resumen:** PR de mayor impacto en la documentación. Aplica las siguientes decisiones consensuadas tras la revisión arquitectónica:
-  - **Scope:** Soporte offline diferido a Fase 2; Portal del Cliente diferido a Fase 1.5; observabilidad (Sentry/Logfire/PostHog) diferida a Fase 2.
-  - **Simplificación de infraestructura:** Celery + Redis → ARQ + cron de Railway; Vercel + Railway → Railway-solo; Schedule-X + TanStack Table en lugar de construir agenda/grids desde cero.
-  - **Alcance IA:** la IA del MVP **estructura** (no genera diagnósticos); Claude tool use + Pydantic schema; prompt caching desde el día 1; selección de modelo por subtarea (`whisper-1`, `claude-haiku-4-5`, `claude-sonnet-4-6`).
-  - **Estándares 2026:** PostgreSQL Row-Level Security como defensa en profundidad; Playwright E2E + syrupy snapshot del prompt; Expo + Tamagui / React Native Web para shared web/mobile UI desde el día 1.
-- **Cambios:** 11 archivos, +1994 / −409 líneas. Incluye `docs/info.md` (nuevo, profundización de cada herramienta + adopción de cambios) y `conversacion.md` (transcripción de la sesión).
+- **Branch:** `feat/us-010` → `dev` *(mergeado, commit `85301a6`)*
+- **Contenido:** `clinical_attachments` (tenant-scoped + RLS), `StorageService` real (Strategy supabase/s3, DI mockeable), `POST/GET /clinical-records/{id}/attachments` (valida el lote antes de subir, signed URL por respuesta), FE con `AttachmentPicker` + grilla de miniaturas + apertura en pestaña nueva. Fix del listener de auditoría para honrar `audit_skip` también en la rama de creates. PR #418 (`fix/clinical-attachments-ux`) pulió la UX (borrar sin abrir, refrescar historial al crear, auto-cerrar).
+
+---
+
+**Listado completo de PRs mergeados a `dev`:**
+
+| PR | US | Feature |
+|---|---|---|
+| #388 | US-001 | Registro de clínica (INFRA + DB + RLS + BE + FE) |
+| #389 | US-002 | Login con JWT + redirección por rol |
+| #390 | US-003 | Gestión de usuarios staff (RBAC) |
+| #391 | US-005 | Registrar cliente |
+| #392 | US-004 | Recuperación de contraseña (migración Resend → SMTP `aiosmtplib`) |
+| #393 | US-006 | Registrar mascota |
+| #394 | US-017 | Crear turno (detección de solapamiento) |
+| #395 | US-007 | Búsqueda global enriquecida |
+| #396 | US-018 | Agenda diaria/semanal (Schedule-X) |
+| #397 | US-009 | Registrar consulta + `audit_log` automático |
+| #398 | US-023 | Registrar vacuna aplicada |
+| #399 | US-019 | Reprogramar / cancelar turno |
+| #400 | US-008 | Perfil clínico completo de la mascota |
+| #401 | US-011 | Historial clínico paginado + `clinical_record_access_log` |
+| #405 | US-020 | Marcar turno atendido e iniciar consulta |
+| #406 | US-020b | Ver/editar la consulta de un turno (sin duplicar, 409) |
+| #407 | US-021 | Recordatorio diario por email (cron + SMTP) |
+| #408 | US-022 | Estado efectivo de notificación del turno |
+| #413 | US-DASH | Dashboard por rol + listados de clientes/mascotas |
+| #414 | US-010 | Adjuntos clínicos (Supabase Storage) |
+| #415 | US-013 | Asistente IA: voz → campos clínicos |
+| #416 | US-014 | Subida de audio externo para pre-llenado IA |
+| #417 | US-012 | Editar/eliminar consulta propia |
+| #418 | — | Fix UX de adjuntos de historia clínica |
+
+> El paso a Done del board es manual: como los PRs apuntan a `dev` (no a `main`, la rama default), el `Closes #N` solo auto-cierra al integrar `dev → main`.

--- a/readme.md
+++ b/readme.md
@@ -15,67 +15,306 @@
 
 ### **0.1. Tu nombre completo:**
 
+Franco Borgato, Mateo Costes
+
 ### **0.2. Nombre del proyecto:**
+
+Veterinary Intelligence Platform
 
 ### **0.3. Descripción breve del proyecto:**
 
+Plataforma web SaaS multi-tenant para la gestión integral de clínicas veterinarias pequeñas (1–5 veterinarios). El diferenciador central es la **asistencia de IA para estructurar historias clínicas**: el veterinario dicta una nota de voz, sube una imagen diagnóstica o ingresa texto libre, y el sistema transcribe y completa automáticamente los campos predefinidos del registro clínico (motivo, síntomas, peso, temperatura, medicación referida). El profesional revisa y confirma antes de guardar. **La IA del MVP no genera diagnósticos ni tratamientos sugeridos** — esa capacidad queda diferida a una etapa posterior con validación regulatoria.
+
+El sistema cubre además gestión de clientes y mascotas, agenda multi-veterinario con detección de solapamientos, vacunación con recordatorios de vencimiento, notificaciones automáticas de turno por email, reportes exportables y auditoría completa de cambios sobre datos clínicos.
+
 ### **0.4. URL del proyecto:**
 
-> Puede ser pública o privada, en cuyo caso deberás compartir los accesos de manera segura. Puedes enviarlos a [alvaro@lidr.co](mailto:alvaro@lidr.co) usando algún servicio como [onetimesecret](https://onetimesecret.com/).
+> Producto aún no desplegado en producción — el proyecto se encuentra en fase de documentación técnica y planificación. No hay URL pública del MVP.
 
 ### 0.5. URL o archivo comprimido del repositorio
 
-> Puedes tenerlo alojado en público o en privado, en cuyo caso deberás compartir los accesos de manera segura. Puedes enviarlos a [alvaro@lidr.co](mailto:alvaro@lidr.co) usando algún servicio como [onetimesecret](https://onetimesecret.com/). También puedes compartir por correo un archivo zip con el contenido
+https://github.com/mateocostes/Veterinary-Intelligence-Platform
 
+Branch principal: `main`. Toda la documentación técnica de esta entrega vive en la rama `docs` (commit `aeeacff` al momento de la entrega).
 
 ---
 
 ## 1. Descripción general del producto
 
-> Describe en detalle los siguientes aspectos del producto:
-
 ### **1.1. Objetivo:**
 
-> Propósito del producto. Qué valor aporta, qué soluciona, y para quién.
+El producto resuelve un problema cuantificable de las clínicas veterinarias pequeñas: **la documentación clínica manual consume ~10 minutos por consulta**, tiempo que el veterinario no puede dedicar al paciente. La plataforma reduce ese tiempo a **menos de 3 minutos por consulta** estructurando automáticamente la historia clínica a partir de lo que el profesional dicta.
+
+**Valor por stakeholder:**
+
+- **Veterinario:** dicta una nota de voz mientras atiende; recibe los campos pre-completados con la información transcrita; revisa, edita lo que necesite y guarda con un click. Reduce la fricción administrativa.
+- **Recepcionista:** gestiona agenda multi-profesional sin solapamientos; el sistema dispara recordatorios automáticos de turno sin llamadas manuales.
+- **Administrador (dueño de la clínica, que suele también ejercer como veterinario):** ve reportes operativos y financieros; audita cambios sobre historias clínicas; controla quién accedió a qué información (cumplimiento Ley 25.326).
+- **Dueño de mascota:** recibe recordatorios automáticos por email; en Fase 1.5 accederá a un portal propio para consultar historial y autogestionar turnos.
+
+**Para quién:** clínicas veterinarias pequeñas argentinas de 1–5 veterinarios, donde el dueño suele también ejercer como profesional clínico, con eventual recepcionista, y con acceso a internet estable durante las consultas.
 
 ### **1.2. Características y funcionalidades principales:**
 
-> Enumera y describe las características y funcionalidades específicas que tiene el producto para satisfacer las necesidades identificadas.
+| Feature | Descripción |
+|---|---|
+| **Historia Clínica Asistida por IA** | Transcripción de voz (Whisper API `whisper-1`) + **estructuración** del contenido en los campos predefinidos de la historia clínica (Claude API con tool use + schema Pydantic; modelo seleccionado por subtarea entre `claude-haiku-4-5` y `claude-sonnet-4-6`). **Prompt caching activado desde el día uno**. La IA NO genera diagnósticos ni tratamientos sugeridos en el MVP — esa capacidad se difiere a una etapa posterior. El veterinario valida y edita antes de guardar. Toda la interacción IA queda auditada en `clinical_records_ai`. |
+| **Gestión de Clientes y Mascotas** | CRUD completo de clientes y pacientes. Perfil unificado que integra historial clínico, vacunas y próximos turnos. Búsqueda por nombre de mascota o dueño con respuesta en < 1 segundo. |
+| **Agenda y Turnos** | Vista diaria y semanal filtrable por veterinario (Schedule-X). Detección de solapamiento de turnos. Estados: Pendiente / Atendido / Cancelado. Transición directa turno → creación de historia clínica. |
+| **Notificaciones Automáticas** | Recordatorios de turno por email (Resend) a 48h y 24h del turno, disparados desde un cron de Railway que corre cada 15 min. Registro del estado de cada envío en `appointment_notifications`. |
+| **Vacunación y Recordatorios** | Registro de vacunas aplicadas con próxima fecha. Listado de vencimientos próximos en los 30 días siguientes (configurable), filtrables por especie y veterinario. Cron diario `notify_due_vaccinations.py` que notifica a la clínica. |
+| **Reportes y Exportación** | Consultas por período, ingresos, mascotas atendidas y vacunas aplicadas. Exportación en PDF y Excel. Reportes financieros sólo para Administrador. |
+| **Auditoría y Trazabilidad** | Registro automático e inmutable de todas las mutaciones sobre datos clínicos/de negocio (`audit_log` con event listener de SQLAlchemy) y de los accesos individuales a historias clínicas (`clinical_record_access_log`). Append-only enforced en motor (`REVOKE UPDATE, DELETE` al rol `app_runtime`). Visible para el Administrador con filtro por entidad y por usuario. |
+
+> **Features diferidos.**
+> - **Portal del Cliente (Fase 1.5):** autenticación independiente para dueños de mascotas (JWT propio con `client_id`); permite ver historial clínico filtrable por veterinario y solicitar/cancelar turnos propios; sin acceso a notas internas ni datos de auditoría IA.
+> - **Soporte Offline (Fase 2):** Service Workers + IndexedDB con caché local de turnos del día e historiales frecuentes y cola de mutaciones sincronizada al reconectar.
+> - **Generación de diagnósticos sugeridos con IA (Fase 2):** requiere validación clínica y regulatoria independiente antes de habilitarse.
+> - **Observabilidad completa (Fase 2):** Sentry + Pydantic Logfire / OpenTelemetry + PostHog. MVP se sostiene con logging estructurado de FastAPI.
 
 ### **1.3. Diseño y experiencia de usuario:**
 
-> Proporciona imágenes y/o videotutorial mostrando la experiencia del usuario desde que aterriza en la aplicación, pasando por todas las funcionalidades principales.
+> El proyecto se encuentra en fase de documentación y planificación. El diseño de interfaz y los flujos de usuario aún no han sido implementados. Los wireframes y capturas de pantalla estarán disponibles una vez iniciado el desarrollo del frontend (Fase 1).
+
+Los flujos principales definidos son:
+
+- **Flujo de consulta con IA:** Veterinario abre ficha de mascota → graba nota de voz → espera transcripción (indicador de carga) → recibe formulario pre-completado con los campos extraídos del audio (motivo, síntomas, peso, temperatura, medicación) → los campos `diagnóstico` y `tratamiento` quedan vacíos para que el profesional los complete → guarda con un click.
+- **Flujo de agenda:** Vista de calendario (Schedule-X) → click en slot disponible → selección de mascota y veterinario → confirmación con detección de solapamiento → recordatorios automáticos por email a 48h y 24h.
+- **Flujo de auditoría:** Administrador entra al detalle de una historia clínica → panel "Historial de cambios" muestra timestamp + usuario + diff campo por campo de cada modificación → panel "Registro de accesos" muestra quién vio la historia y cuándo.
+
+> **Flujos diferidos:** Portal del Cliente (Fase 1.5) — login independiente, listado de mascotas propias, historial cronológico filtrable por veterinario, solicitud de turno.
 
 ### **1.4. Instrucciones de instalación:**
-> Documenta de manera precisa las instrucciones para instalar y poner en marcha el proyecto en local (librerías, backend, frontend, servidor, base de datos, migraciones y semillas de datos, etc.)
+
+> El proyecto está en fase de documentación. El scaffolding de código aún no ha sido generado. Las instrucciones definitivas estarán disponibles una vez completada la Fase 1 del desarrollo. La planificación contempla:
+
+- `docker-compose.yml` para levantar el entorno de desarrollo local (PostgreSQL 16, Redis, Backend FastAPI, Frontend Expo + Vite, ARQ Worker)
+- Variables de entorno en `.env.example` (API keys de OpenAI, Anthropic, Resend, configuración de S3/Supabase, `JWT_SECRET`)
+- Migraciones de base de datos via Alembic (`alembic upgrade head`) — incluyen la activación de Row-Level Security y los GRANTs append-only sobre `audit_log` / `clinical_record_access_log`
+- Datos semilla para desarrollo local (clínica de prueba, usuarios staff, mascotas, turnos)
+- Suite de tests bloqueante en CI: `pytest` para unitarios/integración, `playwright` para E2E del flujo crítico de IA, `syrupy` para snapshot tests del prompt enviado a Claude
 
 ---
 
 ## 2. Arquitectura del Sistema
 
 ### **2.1. Diagrama de arquitectura:**
-> Usa el formato que consideres más adecuado para representar los componentes principales de la aplicación y las tecnologías utilizadas. Explica si sigue algún patrón predefinido, justifica por qué se ha elegido esta arquitectura, y destaca los beneficios principales que aportan al proyecto y justifican su uso, así como sacrificios o déficits que implica.
 
+La arquitectura sigue un patrón de tres capas desacopladas: frontend SPA, backend API REST y base de datos relacional. Los servicios de IA se consumen como APIs externas. El almacenamiento de archivos es independiente de la base de datos. **Todos los servicios viven en un único proyecto de Railway** para simplificar la operación y eliminar CORS interno entre frontend y backend.
+
+```mermaid
+flowchart TD
+  subgraph Client["Cliente (Browser / iOS / Android)"]
+    FE["Expo Router + Tamagui<br/>+ Vite (web) / React Native (móvil)<br/>Schedule-X · TanStack Table"]
+  end
+
+  subgraph Railway["Railway project (single)"]
+    STATIC["Frontend (Static — nginx)"]
+    API["FastAPI Backend<br/>Auth (JWT) · Business Logic · AI Orchestration<br/>+ PostgreSQL RLS por sesión"]
+    ARQ["ARQ Worker<br/>(flujo IA async)"]
+    CRON["Cron jobs<br/>send_appointment_reminders.py · notify_due_vaccinations.py"]
+    RED["Redis managed<br/>(broker ARQ + refresh tokens)"]
+    PG["PostgreSQL 16 managed<br/>Multi-tenancy + Row-Level Security<br/>+ audit_log append-only"]
+  end
+
+  subgraph Storage["Almacenamiento de archivos"]
+    S3["Supabase Storage / S3<br/>(adjuntos clínicos + audios temp)"]
+  end
+
+  subgraph External["APIs Externas"]
+    WHISPER["Whisper API (OpenAI)<br/>transcripción de voz"]
+    CLAUDE["Claude API (Anthropic)<br/>estructuración con tool use + Pydantic"]
+    RESEND["Resend<br/>emails transaccionales"]
+  end
+
+  subgraph Deploy["CI/CD"]
+    GHA["GitHub Actions<br/>lint → test → snapshot → build → deploy"]
+  end
+
+  FE -->|HTTPS| STATIC
+  STATIC -->|reverse proxy /api| API
+  API --> PG
+  API --> S3
+  API --> RED
+  ARQ --> RED
+  ARQ --> WHISPER
+  ARQ --> CLAUDE
+  CRON --> PG
+  CRON --> RESEND
+  GHA --> Railway
+```
+
+*Figure 1: Diagrama de arquitectura general del sistema*
+
+**Patrón elegido:** Arquitectura de tres capas (Presentation / Application / Data) con orquestación async desacoplada (ARQ) para tareas de larga duración y cron jobs de Railway para tareas programadas. Multi-tenancy con **defensa en profundidad**: filtro por `clinic_id` en queries SQLAlchemy + PostgreSQL Row-Level Security como segunda capa en motor.
+
+**Justificación:**
+- **FastAPI + PostgreSQL** proveen un backend tipado, de alta performance y con soporte async nativo. La integración con Pydantic v2 hace que el schema de extracción de IA (`ClinicalRecordExtraction`) sirva simultáneamente como tool_use schema para Claude y como shape del JSONB en `clinical_records_ai`.
+- **Expo (Expo Router + Tamagui)** con build web vía React Native Web permite compartir la UI entre web y móvil (iOS/Android) desde el primer componente — el día que se libere la app móvil no hay un branch separado, sólo se agrega el target correspondiente al mismo monorepo.
+- **ARQ** desacopla el procesamiento de IA (latencia variable de 5–30s en Whisper) de la respuesta HTTP. Async-nativo, mismo Redis que ya se necesita para refresh tokens — sin agregar Celery (que arrastra worker pesado, mala compatibilidad async y operación compleja).
+- **PostgreSQL Row-Level Security** se habilita en todas las tablas con `clinic_id` como defensa de segundo nivel: si una query SQLAlchemy omite el filtro por `clinic_id`, el motor de DB devuelve cero filas en lugar de filtrar entre clínicas. La fuga de datos clínicos entre tenants se vuelve imposible a nivel de motor.
+- **Railway-solo** (todo en un proyecto) elimina la fricción operativa de dos clouds (Vercel + Railway): sin CORS, sin duplicación de envs, sin observabilidad fragmentada. Para un equipo de 2 founders, simplifica drásticamente el día a día.
+
+**Trade-offs:**
+- **Single-cloud:** atado a Railway. Mitigación: todo corre en Docker, migrar a otro proveedor es factible (la portabilidad del stack lo permite).
+- **ARQ es menos maduro que Celery:** menos plugins, menos documentación. Mitigación: para el alcance del MVP (1 worker, ~750 consultas/mes) ARQ alcanza sobradamente.
+- **RLS agrega complejidad de setup:** requiere dos usuarios de DB (`app_runtime` con RLS forzado, `app_admin` con `BYPASSRLS` para Alembic) y `SET LOCAL` por request. Mitigación: el costo se paga una sola vez en la dependencia FastAPI que abre la sesión; el resto del código no se entera.
+- **Soporte offline diferido a Fase 2:** las clínicas con internet inestable pueden tener una experiencia degradada. Mitigación: el MVP asume conectividad estable; la indicación visual de offline se evalúa para Fase 1.
 
 ### **2.2. Descripción de componentes principales:**
 
-> Describe los componentes más importantes, incluyendo la tecnología utilizada
+| Componente | Tecnología | Responsabilidad |
+|---|---|---|
+| **Frontend SPA** | React 18 + TypeScript, Expo Router + Tamagui, Vite (web build), Zustand, TanStack Query, Tailwind CSS, shadcn/ui | Interfaz de usuario web + móvil compartida, gestión de estado local y de servidor, grabación de audio (MediaRecorder API en web / expo-av en nativo) |
+| **Frontend — agenda** | Schedule-X | Vista de agenda con drag & drop, vistas día/semana/mes, recursos por veterinario y detección de overlap |
+| **Frontend — data grids** | TanStack Table v8 + `@tanstack/react-virtual` | Listados densos (mascotas, vacunas próximas, historial) con sorting, filtering, paginación y virtualización |
+| **Backend API** | Python 3.12, FastAPI, Pydantic v2 | REST API con validación, autorización por rol (JWT), orquestación de servicios IA, generación de reportes |
+| **ORM / Migraciones** | SQLAlchemy 2.0 (async), Alembic | Acceso a base de datos tipado y async; migraciones versionadas. Las migraciones corren con `app_admin` (`BYPASSRLS`); las queries de la app corren con `app_runtime` (RLS forzado). |
+| **Worker asíncrono** | ARQ + Redis | Procesamiento del flujo IA (transcripción Whisper + estructuración Claude) sin bloquear la respuesta HTTP |
+| **Tareas programadas** | Cron de Railway | Recordatorios de turno (cada 15 min) y alertas de vacunación (diario), evitando un broker dedicado a notificaciones |
+| **Base de datos** | PostgreSQL 16 | Datos relacionales con multi-tenancy via `clinic_id` + **Row-Level Security** (defensa en profundidad), soft delete en entidades clínicas, JSONB para output estructurado de la IA, audit_log append-only |
+| **Object Storage** | Supabase Storage / AWS S3 | Almacenamiento de archivos adjuntos (imágenes, PDFs, audios) con URLs firmadas de acceso temporal (≤ 1h) |
+| **Whisper API** | OpenAI (`whisper-1`) | Transcripción de audio a texto; procesado de forma asíncrona via ARQ |
+| **Claude API** | Anthropic — modelo por subtarea: `claude-haiku-4-5` para inputs cortos, `claude-sonnet-4-6` para inputs largos o multimodales | **Estructuración** de la historia clínica via tool use + schema Pydantic `ClinicalRecordExtraction`. NO genera diagnósticos. Prompt caching activo (`cache_control: ephemeral`) desde el día 1. |
+| **Resend** | Resend | Envío de emails: recordatorios de turno y recuperación de contraseña (la activación del portal del cliente se incorpora en Fase 1.5) |
 
 ### **2.3. Descripción de alto nivel del proyecto y estructura de ficheros**
 
-> Representa la estructura del proyecto y explica brevemente el propósito de las carpetas principales, así como si obedece a algún patrón o arquitectura específica.
+El proyecto sigue una organización monorepo con separación clara entre frontend y backend:
+
+```
+/
+├── frontend/                 # Expo + React Native Web SPA
+│   └── src/
+│       ├── app/              # Router global (Expo Router), providers
+│       ├── features/         # Módulos por dominio (feature-based)
+│       │   ├── auth/
+│       │   ├── clients/
+│       │   ├── pets/
+│       │   ├── clinical-records/
+│       │   ├── appointments/
+│       │   ├── vaccinations/
+│       │   ├── ai-assistant/
+│       │   ├── reports/
+│       │   ├── audit/        # Paneles de auditoría para Admin
+│       │   └── client-portal/   # Fase 1.5
+│       ├── shared/           # Componentes (Tamagui + shadcn/ui), hooks y utils reutilizables
+│       ├── services/         # Clientes HTTP por módulo (portables a iOS/Android sin cambios)
+│       └── store/            # Stores de Zustand (portables a iOS/Android sin cambios)
+│
+├── backend/                  # FastAPI application
+│   └── app/
+│       ├── core/             # Config, seguridad, dependencias (incluyendo SET LOCAL app.clinic_id)
+│       ├── api/v1/endpoints/ # Un archivo por módulo (auth, users, pets, ai, audit, etc.)
+│       ├── models/           # Modelos SQLAlchemy con AuditableMixin
+│       ├── schemas/          # Schemas Pydantic (request/response + ClinicalRecordExtraction)
+│       ├── crud/             # Operaciones de base de datos
+│       ├── services/         # Lógica de negocio (ai_service, notification_service, audit_logger)
+│       │   └── ai/           # AIProvider (strategy), AnthropicProvider, WhisperTranscriber, ModelSelector
+│       ├── worker/           # ARQ worker (settings + tasks async del flujo IA)
+│       │   └── tasks/ai.py   # transcribe_and_generate
+│       └── jobs/             # Scripts de cron de Railway
+│           ├── send_appointment_reminders.py  # cada 15 min
+│           └── notify_due_vaccinations.py     # diario, 08:00
+│
+├── docs/                     # Documentación técnica completa
+│   ├── idea-inicial.md
+│   ├── prd.md
+│   ├── architecture.md
+│   ├── data-model.md
+│   ├── user-stories.md
+│   ├── info.md               # Profundización de cada herramienta del stack
+│   └── prompts/prompts.md    # Log cronológico de prompts por sesión
+│
+├── entrega1/                 # Esta entrega del curso
+│   ├── readme.md
+│   └── prompts.md
+│
+├── ia-agents/                # Agentes/skills/rules custom para asistencia de IA durante desarrollo
+├── docker-compose.yml        # Entorno de desarrollo local
+└── CLAUDE.md                 # Contexto del proyecto para asistentes de IA
+```
+
+Patrón de arquitectura: **feature-based** en el frontend (cada módulo de dominio contiene sus componentes, hooks, types y lógica), **layered** en el backend (api → services → crud → models). Esta organización permite portabilidad a móvil sin reescritura: las capas `services/` y `store/` se comparten directamente entre web y móvil gracias a Expo.
 
 ### **2.4. Infraestructura y despliegue**
 
-> Detalla la infraestructura del proyecto, incluyendo un diagrama en el formato que creas conveniente, y explica el proceso de despliegue que se sigue
+Todos los servicios viven en un único proyecto de **Railway** para simplificar la operación, eliminar CORS interno y consolidar billing, logs y métricas en un solo dashboard.
+
+```mermaid
+flowchart TD
+  GHA["GitHub Actions (CI/CD)<br/>lint → pytest → playwright → syrupy → build → deploy"]
+  subgraph RAILWAY["Railway project (single)"]
+    STATIC["Frontend (Static Site)"]
+    BACKEND["Backend (Docker — FastAPI)"]
+    WORKER["ARQ Worker (Docker)"]
+    CRON["Cron jobs"]
+    PG["PostgreSQL managed"]
+    REDIS["Redis managed"]
+  end
+
+  GHA -->|push main| RAILWAY
+  STATIC -->|reverse proxy /api| BACKEND
+  BACKEND --> PG
+  BACKEND --> REDIS
+  WORKER --> REDIS
+  CRON --> PG
+```
+
+*Figure 2: Pipeline de infraestructura y despliegue*
+
+| Servicio | Plataforma | Trigger |
+|---|---|---|
+| Frontend (Static Site) | Railway | Deploy automático desde rama `main` |
+| Backend (FastAPI) | Railway (Docker) | Deploy automático desde rama `main` |
+| ARQ Worker | Railway (Docker, mismo proyecto) | Deploy automático desde rama `main` |
+| Cron Jobs | Railway (cron schedules en panel) | Disparados según schedule (cada 15 min / diario) |
+| PostgreSQL | Railway managed | Gestionado por el proveedor |
+| Redis | Railway managed | Gestionado por el proveedor |
+
+| Entorno | Branch | Propósito |
+|---|---|---|
+| Development | `dev` | Desarrollo local con Docker Compose |
+| Staging | `staging` | Validación antes de producción |
+| Production | `main` | Clínicas reales |
+
+Las variables de entorno (API keys, DATABASE_URL, etc.) se configuran en el panel de Railway — nunca en el repositorio. Los secrets se rotan periódicamente.
+
+**Costo estimado mensual (MVP de 3 clínicas piloto, ~750 consultas IA/mes):** ~U$ 55–70/mes (Railway $45 + Whisper $4.50 + Claude $2.50 con caching + S3 $2 + Resend free + dominio $1.25).
 
 ### **2.5. Seguridad**
 
-> Enumera y describe las prácticas de seguridad principales que se han implementado en el proyecto, añadiendo ejemplos si procede
+- **HTTPS obligatorio:** TLS gestionado por Railway en todos los servicios del proyecto (frontend estático, backend, worker).
+- **Autenticación JWT con refresh tokens:** Access token de corta duración firmado con HMAC; refresh tokens almacenados en Redis con rotación. Payload del JWT: `{ user_id, clinic_id, role: "admin"|"vet"|"reception", exp }`.
+- **Multi-tenancy con defensa en profundidad:** Filtro por `clinic_id` en cada query SQLAlchemy **+ PostgreSQL Row-Level Security**. La sesión SQLAlchemy ejecuta `SET LOCAL app.clinic_id = ...` al abrirse; las policies de cada tabla filtran por `current_setting('app.clinic_id')::uuid`. El usuario `app_runtime` que usa la API tiene `FORCE ROW LEVEL SECURITY`. **Suite de tests de aislamiento es bloqueante en CI.**
+- **Portal del cliente aislado** *(Fase 1.5)*: JWT separado con `client_id` autenticado contra tabla `clients`, no `users`. El middleware `ClientPortalAuth` bajo prefijo `/api/v1/client-portal/` es independiente.
+- **Headers de seguridad:** CSP, X-Frame-Options, HSTS configurados como middleware en FastAPI.
+- **Rate limiting:** En endpoints sensibles — login (5 req/min por IP), endpoints IA (10 req/min por clínica).
+- **Cifrado en reposo:** PostgreSQL con encryption at rest (Railway managed); S3/Supabase con cifrado de objetos.
+- **URLs de archivos firmadas:** Expiración máxima de 1 hora para archivos adjuntos.
+- **Soft delete:** Los registros clínicos nunca se eliminan físicamente; `deleted_at` para trazabilidad completa.
+- **Auditoría completa:**
+  - `audit_log` registra todas las mutaciones (CREATE/UPDATE/DELETE/RESTORE) sobre tablas tenant-scoped vía event listener de SQLAlchemy. Almacena `actor_id`, `actor_ip`, `actor_user_agent`, `entity_type`, `entity_id`, `changes` (JSONB con diff old/new), `request_id` para correlación.
+  - `clinical_record_access_log` registra cada lectura individual de una historia clínica.
+  - **Append-only enforced en DB:** `REVOKE UPDATE, DELETE ON audit_log, clinical_record_access_log FROM app_runtime`. La integridad histórica no depende de la disciplina del developer.
+  - Retención de 7 años; anonimización (no borrado) ante derecho al olvido.
+  - Acceso restringido al rol `admin` bajo `/api/v1/audit/*`.
+- **Auditoría de IA:** Toda interacción con Whisper y Claude se almacena en `clinical_records_ai` (input original, transcripción, prompt completo, schema usado, output estructurado, modelo, cache hit/miss tokens, tiempo de procesamiento). Tabla append-only.
+- **Secrets:** Rotados periódicamente; nunca en código fuente.
 
 ### **2.6. Tests**
 
-> Describe brevemente algunos de los tests realizados
+| Tipo | Tecnología | Cobertura |
+|---|---|---|
+| **Unitarios + integración** | pytest + pytest-asyncio | ≥ 80% en `app/api/v1/`; ejecuta < 5 min |
+| **E2E del flujo crítico** | Playwright | Login → crear turno → grabar audio → ver historia clínica pre-completada → confirmar y guardar |
+| **Snapshot del prompt IA** | syrupy | Bloquea el merge cuando el system prompt o el schema enviado a Claude cambian sin actualizar el snapshot — detecta regresiones silenciosas en la calidad de la extracción |
+| **Aislamiento multi-tenant** | pytest (suite custom) | **Bloqueante en CI.** Crea dos clínicas con datos y verifica que ningún endpoint con JWT de la clínica A retorne filas de B; misma verificación entre dos clientes del portal en Fase 1.5 |
+| **Append-only de auditoría** | pytest | Verifica que un intento de `UPDATE` o `DELETE` sobre `audit_log` desde el rol `app_runtime` retorna error de permisos de Postgres |
+| **Frontend** | Vitest + React Native Testing Library | Componentes Tamagui + hooks de TanStack Query |
+| **Accesibilidad** | Lighthouse / axe-core | WCAG 2.1 nivel AA en formulario clínico, agenda, búsqueda |
+
+CI pipeline: `lint → pytest → playwright → syrupy → build → deploy a Railway`, completo en < 10 minutos desde el merge a `main`.
 
 ---
 
@@ -83,52 +322,636 @@
 
 ### **3.1. Diagrama del modelo de datos:**
 
-> Recomendamos usar mermaid para el modelo de datos, y utilizar todos los parámetros que permite la sintaxis para dar el máximo detalle, por ejemplo las claves primarias y foráneas.
+```mermaid
+erDiagram
+  CLINIC ||--o{ USER : has
+  CLINIC ||--o{ CLIENT : has
+  CLINIC ||--o{ PET : has
+  CLIENT ||--o{ PET : owns
+  PET ||--o{ APPOINTMENT : has
+  PET ||--o{ CLINICAL_RECORD : has
+  PET ||--o{ VACCINATION : has
+  USER ||--o{ APPOINTMENT : attends_as_vet
+  USER ||--o{ CLINICAL_RECORD : creates
+  APPOINTMENT ||--o| CLINICAL_RECORD : generates
+  APPOINTMENT ||--o{ APPOINTMENT_NOTIFICATION : triggers
+  CLINICAL_RECORD ||--o{ CLINICAL_ATTACHMENT : has
+  CLINICAL_RECORD ||--o| CLINICAL_RECORD_AI : audited_by
+  CLINICAL_RECORD ||--o{ VACCINATION : linked_to
+  CLINIC ||--o{ AUDIT_LOG : scopes
+  CLINIC ||--o{ CLINICAL_RECORD_ACCESS_LOG : scopes
+  CLINICAL_RECORD ||--o{ CLINICAL_RECORD_ACCESS_LOG : tracks_reads
 
+  CLINIC {
+    uuid id PK
+    string name
+    string plan
+    timestamptz created_at
+  }
+
+  USER {
+    uuid id PK
+    uuid clinic_id FK
+    string email "UNIQUE"
+    string password_hash
+    string role "admin | vet | reception"
+    string first_name
+    string last_name
+    boolean is_active
+    timestamptz last_login_at
+  }
+
+  CLIENT {
+    uuid id PK
+    uuid clinic_id FK
+    string first_name
+    string last_name
+    string email
+    string phone
+    text address
+    text notes
+    boolean portal_enabled "Fase 1.5"
+    string password_hash "Fase 1.5"
+    boolean is_active "Fase 1.5"
+    timestamptz last_login_at "Fase 1.5"
+    timestamptz deleted_at
+  }
+
+  PET {
+    uuid id PK
+    uuid clinic_id FK
+    uuid client_id FK
+    string name
+    string species
+    string breed
+    date birthdate
+    string sex
+    decimal weight_kg
+    text medical_notes
+    timestamptz deleted_at
+  }
+
+  APPOINTMENT {
+    uuid id PK
+    uuid clinic_id FK
+    uuid pet_id FK
+    uuid vet_id FK
+    timestamptz scheduled_at
+    string status "pending | attended | cancelled"
+    text notes
+  }
+
+  APPOINTMENT_NOTIFICATION {
+    uuid id PK
+    uuid appointment_id FK
+    string channel "email"
+    int trigger_hours_before
+    string status "sent | failed | undelivered"
+    timestamptz sent_at
+    text error_message
+  }
+
+  CLINICAL_RECORD {
+    uuid id PK
+    uuid clinic_id FK
+    uuid pet_id FK
+    uuid appointment_id FK "nullable"
+    uuid created_by FK
+    text consultation_reason
+    text symptoms
+    text diagnosis "completado por el vet, no por la IA"
+    text treatment "completado por el vet, no por la IA"
+    text medication
+    decimal weight_kg
+    decimal temperature_c
+    timestamptz deleted_at
+  }
+
+  CLINICAL_ATTACHMENT {
+    uuid id PK
+    uuid clinical_record_id FK
+    text file_url
+    string file_name
+    string file_type
+    int file_size_bytes
+    timestamptz deleted_at
+  }
+
+  CLINICAL_RECORD_AI {
+    uuid id PK
+    uuid clinical_record_id FK
+    string input_type "voice | image | text"
+    text raw_input_url
+    text transcription
+    text prompt_sent
+    string schema_version "ClinicalRecordExtraction.v1"
+    jsonb ai_structured_output "sin diagnosis/treatment"
+    string model_used "whisper-1 | claude-haiku-4-5 | claude-sonnet-4-6"
+    int cache_hit_tokens
+    int cache_write_tokens
+    int processing_time_ms
+  }
+
+  VACCINATION {
+    uuid id PK
+    uuid clinic_id FK
+    uuid pet_id FK
+    uuid clinical_record_id FK
+    uuid administered_by FK
+    string vaccine_name
+    string batch_number
+    date applied_at
+    date next_due_at
+    timestamptz deleted_at
+  }
+
+  AUDIT_LOG {
+    uuid id PK
+    uuid clinic_id FK
+    string actor_type "user | client | system | cron"
+    uuid actor_id
+    inet actor_ip
+    text actor_user_agent
+    string action "create | update | delete | restore"
+    string entity_type
+    uuid entity_id
+    jsonb changes "diff old/new"
+    uuid request_id
+    timestamptz created_at
+  }
+
+  CLINICAL_RECORD_ACCESS_LOG {
+    uuid id PK
+    uuid clinic_id FK
+    uuid clinical_record_id FK
+    string actor_type
+    uuid actor_id
+    inet actor_ip
+    string access_type "view | export | print"
+    timestamptz created_at
+  }
+```
+
+*Figure 3: Diagrama ER del modelo de datos del MVP (Fase 1) + extensión Fase 1.5 (campos de Portal del Cliente en `clients`)*
 
 ### **3.2. Descripción de entidades principales:**
 
-> Recuerda incluir el máximo detalle de cada entidad, como el nombre y tipo de cada atributo, descripción breve si procede, claves primarias y foráneas, relaciones y tipo de relación, restricciones (unique, not null…), etc.
+**Convenciones globales:** UUID como PK en todos los modelos; `created_at` y `updated_at` en todas las tablas; soft delete con `deleted_at` en modelos clínicos y de negocio; `clinic_id` presente en todas las entidades para multi-tenancy (con RLS habilitado en cada tabla); montos en centavos (INTEGER) para evitar errores de punto flotante.
+
+#### `clinics`
+Entidad raíz del multi-tenancy. Cada clínica es un tenant aislado.
+**Campos clave:** `id` (UUID, PK), `name` (NOT NULL), `plan` (`free`/`pro`/`clinic`), `created_at`.
+
+#### `users`
+Personal de la clínica (Admin, Veterinario, Recepcionista). Authn con JWT propio.
+**Campos clave:** `id` (UUID, PK), `clinic_id` (FK, NOT NULL), `email` (NOT NULL, UNIQUE), `password_hash` (bcrypt), `role` (NOT NULL).
+**Índices:** `(clinic_id)`, `(email)`.
+
+#### `clients`
+Dueños de mascotas. *El acceso opcional al portal de autogestión y los campos asociados se incorporan en Fase 1.5.*
+**Campos clave (Fase 1):** `id` (UUID, PK), `clinic_id` (FK, NOT NULL), `email` (NULL en Fase 1; pasa a NOT NULL al habilitar el portal en Fase 1.5).
+**Campos adicionales (Fase 1.5 — Portal del Cliente):** `portal_enabled` (DEFAULT false), `password_hash` (NULL hasta activación), `is_active` (DEFAULT true), `last_login_at`.
+**Nota:** El campo `notes` (notas internas de la clínica) no es visible desde el portal del cliente.
+**Índices:** `(clinic_id)`, `(clinic_id, last_name)`, `(clinic_id, email)`.
+
+#### `pets`
+Mascotas / pacientes. Cada mascota pertenece a un cliente y a una clínica.
+**Campos clave:** `id`, `clinic_id` (FK), `client_id` (FK), `name`, `species`, `breed`, `birthdate`, `weight_kg`, `deleted_at`.
+**Índices:** `(clinic_id)`, `(client_id)`, `(clinic_id, name)`.
+
+#### `appointments`
+Turnos. Cada turno se asocia a una mascota y a un veterinario específico.
+**Campos clave:** `id`, `clinic_id`, `pet_id`, `vet_id` (FK → users), `scheduled_at`, `status` (`pending`/`attended`/`cancelled`).
+**Constraint:** índice único parcial sobre `(vet_id, scheduled_at)` donde `status = 'pending'` para prevenir solapamientos.
+**Índices:** `(clinic_id, scheduled_at)`, `(vet_id, scheduled_at)`, `(pet_id)`, `(status)`.
+
+#### `clinical_records`
+Consultas médicas. Núcleo del sistema. Nunca se eliminan físicamente (soft delete).
+**Campos clave:** `id`, `pet_id` (FK), `appointment_id` (FK, NULL — puede ser consulta directa sin turno previo), `created_by` (FK → users), `consultation_reason` (NOT NULL), `symptoms`, `diagnosis`, `treatment`, `medication`, `weight_kg`, `temperature_c`, `deleted_at`.
+**Índices:** `(pet_id, created_at DESC)`, `(clinic_id)`.
+
+#### `clinical_records_ai`
+Auditoría completa del flujo de **estructuración** IA. Tabla append-only, no visible para el veterinario en la UI normal.
+**Campos clave:** `clinical_record_id` (FK), `input_type` (voice/image/text), `raw_input_url` (archivo original en S3), `transcription` (output de Whisper), `prompt_sent` (prompt completo + schema), `schema_version`, `ai_structured_output` (JSONB con los campos extraídos según schema Pydantic — **sin** `diagnosis` ni `treatment` en el MVP), `model_used` (whisper-1, claude-haiku-4-5 o claude-sonnet-4-6 según subtarea), `cache_hit_tokens`, `cache_write_tokens`, `processing_time_ms`.
+**Índices:** `(clinical_record_id)`, `(model_used, created_at)` para análisis de costo/calidad por modelo.
+
+#### `audit_log`
+Auditoría de mutaciones (CREATE/UPDATE/DELETE/RESTORE) sobre todas las tablas tenant-scoped. **Append-only enforced en DB** (`REVOKE UPDATE, DELETE` al rol `app_runtime`).
+**Campos clave:** `clinic_id` (con RLS), `actor_type` (`user`/`client`/`system`/`cron`), `actor_id`, `actor_ip`, `actor_user_agent`, `action`, `entity_type`, `entity_id`, `changes` (JSONB con diff old/new), `request_id`.
+**Índices:** `(clinic_id, entity_type, entity_id, created_at DESC)`, `(clinic_id, actor_id, created_at DESC)`.
+
+#### `clinical_record_access_log`
+Auditoría de lecturas individuales de historias clínicas (cumplimiento Ley 25.326). Append-only.
+**Campos clave:** `clinical_record_id` (FK), `actor_type`, `actor_id`, `actor_ip`, `access_type` (`view`/`export`/`print`).
+
+#### `vaccinations`, `clinical_attachments`, `appointment_notifications`
+Entidades complementarias. Detalle completo en [docs/data-model.md](../docs/data-model.md).
+
+> **Entidades de Fase 2** *(schema definido para no requerir cambios estructurales al implementarse):* `services` (servicios cobrables), `payments` (pagos contra servicios), `inventory_items` (stock de medicamentos).
 
 ---
 
 ## 4. Especificación de la API
 
-> Si tu backend se comunica a través de API, describe los endpoints principales (máximo 3) en formato OpenAPI. Opcionalmente puedes añadir un ejemplo de petición y de respuesta para mayor claridad
+Endpoints más representativos del flujo diferenciador del producto (asistencia IA para historias clínicas).
+
+```yaml
+openapi: 3.1.0
+info:
+  title: Veterinary Intelligence Platform API
+  version: v1
+  description: |
+    REST API multi-tenant para gestión clínica veterinaria con IA.
+    Todos los endpoints requieren JWT con `clinic_id` en el payload.
+    Multi-tenancy adicional reforzada con PostgreSQL Row-Level Security.
+servers:
+  - url: https://app.veterinaria.ar/api/v1
+    description: Production (Railway)
+
+paths:
+  /ai/transcribe:
+    post:
+      summary: Encolar transcripción de audio
+      description: |
+        Recibe un archivo de audio, lo sube a S3 temporal y encola una tarea ARQ
+        que llamará a Whisper API. Retorna un task_id que el frontend usa para hacer polling.
+      security: [{ bearerAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                audio:
+                  type: string
+                  format: binary
+                  description: Archivo MP3, MP4, WAV, M4A o WebM (máx. 20 MB)
+                pet_id:
+                  type: string
+                  format: uuid
+              required: [audio, pet_id]
+      responses:
+        '202':
+          description: Tarea encolada
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  task_id: { type: string, format: uuid }
+                  status: { type: string, enum: [queued] }
+        '400': { description: Audio inválido o > 20 MB }
+        '401': { description: JWT inválido o ausente }
+        '403': { description: Rol distinto de `vet` o `admin` }
+
+  /ai/extract-record:
+    post:
+      summary: Estructurar contenido en los campos de la historia clínica
+      description: |
+        Recibe la transcripción (o texto libre / descripción de imagen) y la estructura
+        en los campos predefinidos usando Claude con tool use + schema Pydantic
+        (`ClinicalRecordExtraction`). NO genera diagnósticos ni tratamientos sugeridos.
+        Prompt caching activo: el system prompt + schema se cachean entre llamadas.
+      security: [{ bearerAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                transcript: { type: string }
+                pet_id: { type: string, format: uuid }
+                input_type: { type: string, enum: [voice, image, text] }
+              required: [transcript, pet_id, input_type]
+      responses:
+        '200':
+          description: Campos extraídos
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  extraction:
+                    type: object
+                    properties:
+                      consultation_reason: { type: string, nullable: true }
+                      symptoms: { type: string, nullable: true }
+                      weight_kg: { type: number, nullable: true }
+                      temperature_c: { type: number, nullable: true }
+                      medication_taken: { type: string, nullable: true }
+                      schema_version: { type: string, example: "v1" }
+                  diagnosis: { type: string, nullable: true, description: "Siempre null en MVP — completar manualmente" }
+                  treatment: { type: string, nullable: true, description: "Siempre null en MVP — completar manualmente" }
+                  ai_audit_id: { type: string, format: uuid, description: "ID en clinical_records_ai" }
+                  model_used: { type: string }
+                  cache_hit_tokens: { type: integer }
+        '422': { description: Output de Claude no cumple el schema Pydantic }
+        '504': { description: Timeout > 30s — fallback a entrada manual }
+
+  /clinical-records:
+    post:
+      summary: Crear historia clínica
+      description: |
+        Persiste la historia clínica validada por el veterinario (luego de editar el pre-fill IA).
+        Inserción atómica en `clinical_records` + `clinical_records_ai`. Event listener de
+        SQLAlchemy registra automáticamente el insert en `audit_log`.
+      security: [{ bearerAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pet_id: { type: string, format: uuid }
+                appointment_id: { type: string, format: uuid, nullable: true }
+                consultation_reason: { type: string }
+                symptoms: { type: string }
+                diagnosis: { type: string }
+                treatment: { type: string }
+                medication: { type: string }
+                weight_kg: { type: number }
+                temperature_c: { type: number }
+                ai_audit_id: { type: string, format: uuid, nullable: true, description: "Vincula con clinical_records_ai si se usó IA" }
+              required: [pet_id, consultation_reason]
+      responses:
+        '201': { description: Creada }
+        '403': { description: Rol distinto de `vet` o `admin` }
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+```
 
 ---
 
 ## 5. Historias de Usuario
 
-> Documenta 3 de las historias de usuario principales utilizadas durante el desarrollo, teniendo en cuenta las buenas prácticas de producto al respecto.
+**Historia de Usuario 1 — Historia Clínica Asistida por IA (US-013)**
 
-**Historia de Usuario 1**
+Como Veterinario, quiero grabar una nota de voz durante o después de la consulta y que la app **complete los campos predefinidos de la historia clínica** a partir de lo dictado, para reducir el tiempo de escritura administrativa.
 
-**Historia de Usuario 2**
+**Criterios de aceptación:**
+- Puedo iniciar y detener la grabación desde la app (sin aplicación externa)
+- Veo un indicador de estado de carga mientras se procesa el audio
+- Recibo los campos pre-completados con la información extraída del audio: motivo de consulta, síntomas, peso, temperatura, medicación referida
+- Los campos `diagnóstico` y `tratamiento` quedan **vacíos** para que yo los complete — la IA no genera diagnósticos ni sugerencias terapéuticas en esta etapa
+- La UI muestra explícitamente el alcance: "El asistente completa los campos a partir de lo dictado. No sugiere diagnósticos ni tratamientos"
+- Puedo editar cualquier campo antes de guardar
+- Si el procesamiento falla (timeout > 30s), puedo completar el formulario manualmente sin perder lo ingresado
+- El registro queda guardado junto con el audio original y la extracción IA para auditoría
 
-**Historia de Usuario 3**
+---
+
+**Historia de Usuario 2 — Agenda multi-veterinario sin solapamientos (US-017)**
+
+Como Recepcionista o Veterinario, quiero crear un turno asignado a una mascota y un veterinario específico, para organizar la agenda de la clínica sin solapamientos.
+
+**Criterios de aceptación:**
+- Debo seleccionar: mascota (con búsqueda por nombre), veterinario, fecha, hora y motivo
+- El sistema detecta solapamiento: si el veterinario ya tiene un turno en ese horario, muestra error claro con el horario conflictivo (HTTP 409)
+- El turno creado queda en estado "Pendiente" y aparece inmediatamente en la agenda (Schedule-X)
+- Se genera automáticamente una notificación de recordatorio por email para el dueño (48h y 24h antes), disparada por el cron `send_appointment_reminders.py` que corre cada 15 min
+
+---
+
+**Historia de Usuario 3 — Auditoría de cambios en historia clínica (US-039)**
+
+Como Administrador, quiero ver el historial completo de cambios sobre una historia clínica, para entender quién modificó qué y cuándo ante cualquier consulta o reclamo.
+
+**Criterios de aceptación:**
+- Accedo desde el detalle de la historia clínica a un panel "Historial de cambios"
+- Cada entrada muestra: timestamp, quién (nombre + rol), acción (create/update/delete), y para updates el diff campo por campo (valor anterior → valor nuevo)
+- Puedo filtrar por usuario y por rango de fechas
+- Los usuarios `vet` y `reception` no ven este panel; el endpoint subyacente (`GET /api/v1/audit/clinical-records/{id}`) retorna HTTP 403
+- Los datos vienen de `audit_log`, que es append-only enforced en DB — ningún registro de cambio puede ser modificado o eliminado
 
 ---
 
 ## 6. Tickets de Trabajo
 
-> Documenta 3 de los tickets de trabajo principales del desarrollo, uno de backend, uno de frontend, y uno de bases de datos. Da todo el detalle requerido para desarrollar la tarea de inicio a fin teniendo en cuenta las buenas prácticas al respecto. 
+> Documenta 3 de los tickets de trabajo principales del desarrollo, uno de backend, uno de frontend, y uno de bases de datos. Da todo el detalle requerido para desarrollar la tarea de inicio a fin teniendo en cuenta las buenas prácticas al respecto.
 
-**Ticket 1**
+Los tres tickets seleccionados cubren el flujo diferenciador del MVP: la historia clínica asistida por IA. Son los más representativos de la arquitectura del sistema, abarcan las tres capas solicitadas (backend, frontend, base de datos) y sus criterios de aceptación son verificables de forma autónoma por un agente de IA.
 
-**Ticket 2**
+---
 
-**Ticket 3**
+### Ticket 1 — Backend · `US-013-BE` · Talla: M
+
+**Título:** Endpoint de transcripción de voz con pipeline IA asíncrono
+
+**Historia de usuario:** Como Veterinario, quiero grabar una nota de voz durante o después de la consulta y que la app complete automáticamente los campos de la historia clínica con lo que dicté, para reducir el tiempo de escritura administrativa.
+
+**Descripción técnica:**
+
+Implementar `POST /ai/transcribe-voice` que recibe el archivo de audio grabado desde el frontend, lo sube a S3/Supabase Storage como archivo temporal y encola una tarea ARQ devolviendo `{"task_id": "<uuid>", "status": "pending"}` (HTTP 202). El resultado se recupera con `GET /ai/tasks/{task_id}`.
+
+La tarea ARQ ejecuta el siguiente pipeline en secuencia:
+
+1. **Transcripción:** llama a Whisper API (`whisper-1`) con el audio recuperado de S3.
+2. **Limpieza:** pasa la transcripción a `claude-haiku-4-5` para normalizar abreviaciones y corregir errores tipográficos.
+3. **Extracción estructurada:** invoca Claude (`claude-sonnet-4-6`) con tool use + schema Pydantic `ClinicalRecordExtraction`. El system prompt tiene `cache_control: {"type": "ephemeral"}` para activar prompt caching. El schema tiene los campos `reason`, `symptoms`, `weight`, `temperature`, `referred_medication` como `Optional[str]`; los campos `diagnosis` y `treatment` son siempre `None` (nunca se populan en el MVP).
+4. **Auditoría:** inserta una fila en `clinical_records_ai` con `input_type`, `transcription`, `full_prompt`, `schema_used`, `structured_output`, `model`, `cache_hit`, `cache_tokens_read`, `processing_time_ms`, `status`.
+
+Timeout de 30 s: si el pipeline supera ese límite, el task retorna `status: "failed"`. El archivo temporal en S3 se elimina tras el procesamiento (exitoso o fallido).
+
+**Stack involucrado:** FastAPI · ARQ + Redis · Whisper API (`whisper-1`) · Claude API (`claude-haiku-4-5` + `claude-sonnet-4-6`) · Pydantic v2 · Supabase Storage / S3 · pytest + syrupy
+
+**Criterios de aceptación (BDD):**
+
+*Escenario 1 — Happy path:*
+- **Dado que** el veterinario autenticado (rol `vet` o `admin`) envía `POST /ai/transcribe-voice` con un audio válido (WebM, WAV, M4A, MP3, MP4, ≤ 20 MB)
+- **Cuando** el endpoint encola la tarea ARQ y el worker la procesa en menos de 30 s
+- **Entonces** `POST` responde HTTP 202 con `{"task_id": "<uuid>", "status": "pending"}`; al consultar `GET /ai/tasks/{task_id}` el sistema devuelve `status: "completed"` con `structured_output` conteniendo `reason`, `symptoms`, `weight`, `temperature`, `referred_medication` extraídos del audio, y `diagnosis` y `treatment` como `null`; la tabla `clinical_records_ai` contiene una fila con todos los campos de auditoría
+
+*Escenario 2 — Audio sin datos clínicos reconocibles:*
+- **Dado que** el audio contiene solo ruido o contenido sin información clínica estructurable
+- **Cuando** el worker procesa la transcripción con Claude tool use
+- **Entonces** el task devuelve `status: "completed"` con todos los campos clínicos como `null` o cadenas vacías; no se lanza excepción; `clinical_records_ai` registra el output vacío con el prompt y modelo usados
+
+*Escenario 3 — Timeout del worker (> 30 s):*
+- **Dado que** el procesamiento del audio supera el límite de 30 s
+- **Cuando** el cliente consulta `GET /ai/tasks/{task_id}`
+- **Entonces** el sistema devuelve `status: "failed"` con `error: "Processing timeout — please fill the form manually"`; la tarea no reintenta automáticamente; `clinical_records_ai` registra `status: "timeout"` con el tiempo transcurrido
+
+**INVEST:** I✅ N✅ V✅ E✅ S✅ T✅
+
+**Estimación y justificación (M):** Complejidad moderada por el pipeline de 3 pasos (Whisper → haiku → sonnet), la lógica de timeout en ARQ y el setup del prompt caching. Sin incertidumbre técnica mayor — todos los componentes están definidos; la integración es punto por punto. Estimado 3–4 días.
+
+**Dependencias:** US-013-DB (tabla `clinical_records_ai` debe existir para el paso de auditoría) · US-013-AI (schema `ClinicalRecordExtraction` y prompt del sistema)
+
+---
+
+### Ticket 2 — Frontend · `US-013-FE` · Talla: M
+
+**Título:** Grabación de voz en app con polling y pre-llenado de campos clínicos
+
+**Historia de usuario:** Como Veterinario, quiero grabar una nota de voz durante o después de la consulta y que la app complete automáticamente los campos de la historia clínica con lo que dicté, para reducir el tiempo de escritura administrativa.
+
+**Descripción técnica:**
+
+Implementar dos componentes y un hook custom dentro de `frontend/src/features/ai-assistant/`:
+
+**`VoiceRecorder`** — componente que abstrae la grabación de audio en web (MediaRecorder API) y en nativo (expo-av), con estados `idle → recording → processing → done | error`. Expone `onAudioReady(blob: Blob)` que el padre llama al detener la grabación.
+
+**`useAIPolling(taskId: string)`** — hook TanStack Query que hace polling a `GET /ai/tasks/{task_id}` cada 2 s, se detiene al recibir `status: "completed"` o `status: "failed"`, y dispara un fallback automático a los 35 s. Devuelve `{ data, isLoading, isError, timedOut }`.
+
+**`ClinicalRecordForm`** — formulario existente (o nuevo si aún no existe) que consume el resultado del hook para pre-llenar los 5 campos clínicos (`reason`, `symptoms`, `weight`, `temperature`, `referred_medication`). Los campos `diagnosis` y `treatment` no se pre-llenan. Todos los campos son editables antes de guardar. Muestra el disclaimer: *"El asistente completa los campos a partir de lo dictado. No sugiere diagnósticos ni tratamientos."* visible en todo momento mientras hay un resultado IA activo.
+
+Validación de los campos con Zod antes de enviar el formulario a `POST /clinical-records`. Si el polling retorna `timedOut: true` o `isError: true`, muestra el mensaje de fallback y habilita la entrada manual completa.
+
+**Stack involucrado:** Expo Router · Tamagui · TanStack Query · Zustand · Zod · MediaRecorder API (web) / expo-av (nativo)
+
+**Criterios de aceptación (BDD):**
+
+*Escenario 1 — Happy path:*
+- **Dado que** el veterinario pulsa "Grabar", dicta la nota clínica y pulsa "Detener"
+- **Cuando** el audio se envía a `POST /ai/transcribe-voice` y el polling recibe `status: "completed"` dentro de los 30 s
+- **Entonces** los campos `motivo`, `síntomas`, `peso`, `temperatura` y `medicación referida` se pre-llenan con el output estructurado; los campos `diagnóstico` y `tratamiento` permanecen vacíos; el disclaimer es visible; todos los campos son editables antes de guardar
+
+*Escenario 2 — Campos parcialmente extraídos:*
+- **Dado que** el audio contiene solo motivo y síntomas sin peso ni temperatura
+- **Cuando** el polling recibe el resultado
+- **Entonces** los campos `peso` y `temperatura` muestran su placeholder vacío (no "null"); el veterinario puede completarlos manualmente sin que el formulario los marque como error requerido
+
+*Escenario 3 — Timeout o error de procesamiento:*
+- **Dado que** el polling supera los 35 s o recibe `status: "failed"`
+- **Cuando** el componente detecta el fallo
+- **Entonces** se muestra el mensaje "No se pudo procesar el audio. Podés completar el formulario manualmente." y el formulario queda habilitado para entrada manual sin datos pre-llenados; el botón de grabación queda disponible para reintentar
+
+**INVEST:** I✅ N✅ V✅ E✅ S✅ T✅
+
+**Estimación y justificación (M):** Complejidad moderada por la abstracción MediaRecorder/expo-av (comportamientos distintos en web y nativo) y la lógica del hook de polling con estados diferenciados (loading / completed / failed / timedOut). El formulario clínico en sí es straightforward. Estimado 3–4 días.
+
+**Dependencias:** US-013-BE (endpoint `POST /ai/transcribe-voice` y `GET /ai/tasks/{task_id}` disponibles o mockeados)
+
+---
+
+### Ticket 3 — Base de datos · `US-039-DB` · Talla: M
+
+**Título:** Tabla `audit_log` append-only con REVOKE y listener SQLAlchemy automático
+
+**Historia de usuario:** Como Administrador, quiero ver el historial completo de cambios sobre una historia clínica, para entender quién modificó qué y cuándo ante cualquier consulta o reclamo.
+
+**Descripción técnica:**
+
+Crear la migración Alembic `003_audit_log.py` que establece la tabla `audit_log` y su infraestructura de seguridad:
+
+**Schema de la tabla:**
+```sql
+CREATE TABLE audit_log (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    clinic_id   UUID NOT NULL REFERENCES clinics(id),
+    table_name  TEXT NOT NULL,
+    record_id   UUID NOT NULL,
+    action      TEXT NOT NULL CHECK (action IN ('create','update','delete','soft_delete')),
+    changed_by_user_id UUID REFERENCES users(id),
+    changes     JSONB,           -- {"field": {"before": ..., "after": ...}}
+    changed_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+**Append-only enforced en motor:**
+```sql
+REVOKE UPDATE, DELETE ON audit_log FROM app_runtime;
+```
+El rol `app_runtime` (usado por la API en producción) solo puede INSERT. Ningún código de aplicación — ni un bug, ni una vulnerabilidad — puede modificar o eliminar un registro de auditoría.
+
+**Índices para queries de auditoría:**
+```sql
+CREATE INDEX ix_audit_log_record
+    ON audit_log (clinic_id, table_name, record_id, changed_at DESC);
+CREATE INDEX ix_audit_log_user
+    ON audit_log (clinic_id, changed_by_user_id, changed_at DESC);
+```
+
+**Listener SQLAlchemy (`backend/app/services/audit_logger.py`):**
+
+```python
+from sqlalchemy import event
+from sqlalchemy.orm import Session
+
+AUDITED_MODELS = {ClinicalRecord, Appointment, Pet, Client, User, Vaccination}
+
+@event.listens_for(Session, "after_flush")
+def auto_audit(session: Session, flush_context):
+    for obj in (*session.new, *session.dirty, *session.deleted):
+        if type(obj) not in AUDITED_MODELS:
+            continue
+        action = _detect_action(obj, session)
+        changes = _build_diff(obj, session)
+        session.execute(
+            insert(AuditLog).values(
+                clinic_id=obj.clinic_id,
+                table_name=obj.__tablename__,
+                record_id=obj.id,
+                action=action,
+                changed_by_user_id=get_current_user_id(),
+                changes=changes,
+            )
+        )
+```
+
+El listener es transparente para el resto del código: ningún endpoint necesita llamarlo explícitamente.
+
+**Política de retención:** 7 años. La purga de registros vencidos solo puede ejecutarla el rol `app_admin` (con `BYPASSRLS`), mediante script documentado en `backend/scripts/purge_audit_log.py`.
+
+**Stack involucrado:** PostgreSQL 16 · Alembic · SQLAlchemy 2.0 (async) · pytest (tests de append-only y aislamiento)
+
+**Criterios de aceptación (BDD):**
+
+*Escenario 1 — Happy path (mutación registrada automáticamente):*
+- **Dado que** el listener SQLAlchemy está activo y el rol `app_runtime` actualiza una historia clínica (PATCH `/clinical-records/{id}`)
+- **Cuando** la sesión hace flush
+- **Entonces** se inserta automáticamente una fila en `audit_log` con `table_name: "clinical_records"`, el `record_id` correcto, `action: "update"`, el `changed_by_user_id` del contexto de sesión y el diff campo por campo en el JSONB `changes`; ningún endpoint necesita llamar explícitamente al listener
+
+*Escenario 2 — Append-only garantizado:*
+- **Dado que** existen filas en `audit_log` y el rol en uso es `app_runtime`
+- **Cuando** se ejecuta `UPDATE audit_log SET action = 'x' WHERE id = :id` o `DELETE FROM audit_log WHERE id = :id`
+- **Entonces** PostgreSQL lanza `ERROR: permission denied for table audit_log` y la operación se revierte; la fila original permanece intacta; este test es bloqueante en CI
+
+*Escenario 3 — Query usa índice compuesto (rendimiento):*
+- **Dado que** `audit_log` tiene 100.000 filas distribuidas entre múltiples clínicas
+- **Cuando** se ejecuta `GET /api/v1/audit/clinical-records/{id}/mutations` con filtros de fecha
+- **Entonces** el query plan muestra `Index Scan` sobre `ix_audit_log_record` y la latencia del endpoint es < 200 ms en el percentil 95
+
+**INVEST:** I✅ N✅ V✅ E✅ S✅ T✅
+
+**Estimación y justificación (M):** Complejidad moderada por tres razones: (1) el REVOKE requiere configuración de dos roles Postgres (`app_runtime` / `app_admin`) coordinada con la migración de RLS de US-001-DB; (2) el listener SQLAlchemy necesita detectar correctamente `new` / `dirty` / `deleted` y construir el diff de forma genérica para todos los modelos auditables; (3) los tests de append-only deben verificar el comportamiento directamente en el motor Postgres, no solo en la capa ORM. Estimado 3–4 días.
+
+**Dependencias:** US-001-DB (roles `app_runtime` y `app_admin` deben existir en la BD) · `AuditableMixin` en los modelos SQLAlchemy
 
 ---
 
 ## 7. Pull Requests
 
-> Documenta 3 de las Pull Requests realizadas durante la ejecución del proyecto
+> El proyecto se encuentra en fase de documentación técnica. Las PRs documentadas a continuación corresponden a la rama `docs` donde vive toda la documentación de esta entrega. Las PRs de scaffolding de código (backend, frontend) están planificadas para iniciarse al cerrar Fase 1.
 
-**Pull Request 1**
+**Pull Request 1 — Documentación técnica inicial (commit `cdc103f`)**
 
-**Pull Request 2**
+- **Branch:** `docs` → `main` *(pendiente de mergear; se mantiene en docs hasta validación con tutores)*
+- **Commit:** `cdc103f docs: add technical documentation and project structure`
+- **Contenido:** Setup inicial del repo. Creación de `docs/` con `idea-inicial.md` (concepto + roles + stack), `prd.md` (PRD completo de 15 secciones con 9 diagramas Mermaid), `architecture.md` (stack, estructura, infra, flujo IA), `data-model.md` (ERD + tablas), `user-stories.md` (historias por módulo).
+- **Cambios:** +5500 líneas de documentación.
 
-**Pull Request 3**
+**Pull Request 2 — Portal del cliente + entrega1 + ia-agents (commit `2dd272d`)**
 
+- **Branch:** `docs` → `main` *(pendiente)*
+- **Commit:** `2dd272d docs: add client portal, entrega1 artifacts and ia-agents`
+- **Contenido:** Incorporación del Portal del Cliente al modelo (luego diferido a Fase 1.5), creación de los artefactos de esta entrega (`entrega1/readme.md`, `entrega1/prompts.md`) y de la carpeta `ia-agents/` con agentes/skills/rules custom para asistencia de IA durante el desarrollo.
+
+**Pull Request 3 — Revisión arquitectónica para alcance MVP + estándares 2026 (commit `aeeacff`)**
+
+- **Branch:** `docs` → `main` *(pendiente)*
+- **Commit:** `aeeacff docs: revise architecture for MVP scope and 2026 standards`
+- **Resumen:** PR de mayor impacto en la documentación. Aplica las siguientes decisiones consensuadas tras la revisión arquitectónica:
+  - **Scope:** Soporte offline diferido a Fase 2; Portal del Cliente diferido a Fase 1.5; observabilidad (Sentry/Logfire/PostHog) diferida a Fase 2.
+  - **Simplificación de infraestructura:** Celery + Redis → ARQ + cron de Railway; Vercel + Railway → Railway-solo; Schedule-X + TanStack Table en lugar de construir agenda/grids desde cero.
+  - **Alcance IA:** la IA del MVP **estructura** (no genera diagnósticos); Claude tool use + Pydantic schema; prompt caching desde el día 1; selección de modelo por subtarea (`whisper-1`, `claude-haiku-4-5`, `claude-sonnet-4-6`).
+  - **Estándares 2026:** PostgreSQL Row-Level Security como defensa en profundidad; Playwright E2E + syrupy snapshot del prompt; Expo + Tamagui / React Native Web para shared web/mobile UI desde el día 1.
+- **Cambios:** 11 archivos, +1994 / −409 líneas. Incluye `docs/info.md` (nuevo, profundización de cada herramienta + adopción de cambios) y `conversacion.md` (transcripción de la sesión).

--- a/readme.md
+++ b/readme.md
@@ -1,114 +1,114 @@
-## Índice
+## Index
 
-0. [Ficha del proyecto](#0-ficha-del-proyecto)
-1. [Descripción general del producto](#1-descripción-general-del-producto)
-2. [Arquitectura del sistema](#2-arquitectura-del-sistema)
-3. [Modelo de datos](#3-modelo-de-datos)
-4. [Especificación de la API](#4-especificación-de-la-api)
-5. [Historias de usuario](#5-historias-de-usuario)
-6. [Tickets de trabajo](#6-tickets-de-trabajo)
+0. [Project sheet](#0-project-sheet)
+1. [Product overview](#1-product-overview)
+2. [System architecture](#2-system-architecture)
+3. [Data model](#3-data-model)
+4. [API specification](#4-api-specification)
+5. [User stories](#5-user-stories)
+6. [Work tickets](#6-work-tickets)
 7. [Pull requests](#7-pull-requests)
 
 ---
 
-## 0. Ficha del proyecto
+## 0. Project sheet
 
-### **0.1. Tu nombre completo:**
+### **0.1. Your full name:**
 
 Franco Borgato, Mateo Costes
 
-### **0.2. Nombre del proyecto:**
+### **0.2. Project name:**
 
 Veterinary Intelligence Platform
 
-### **0.3. Descripción breve del proyecto:**
+### **0.3. Short project description:**
 
-Plataforma web SaaS multi-tenant para la gestión integral de clínicas veterinarias pequeñas (1–5 veterinarios). El diferenciador central es la **asistencia de IA para estructurar historias clínicas**: el veterinario graba una nota de voz (o sube un archivo de audio) y el sistema transcribe y completa automáticamente los campos predefinidos del registro clínico (motivo, síntomas, peso, temperatura, medicación referida y —cuando el profesional los dicta explícitamente— diagnóstico y tratamiento). El profesional revisa y confirma antes de guardar. **La IA nunca inventa diagnósticos ni tratamientos**: solo estructura lo que el veterinario efectivamente dictó.
+Multi-tenant web SaaS platform for the comprehensive management of small veterinary clinics (1–5 veterinarians). The core differentiator is **AI assistance for structuring clinical records**: the veterinarian records a voice note (or uploads an audio file) and the system transcribes and automatically fills in the predefined fields of the clinical record (reason, symptoms, weight, temperature, referred medication and —when the professional dictates them explicitly— diagnosis and treatment). The professional reviews and confirms before saving. **The AI never invents diagnoses or treatments**: it only structures what the veterinarian actually dictated.
 
-El sistema cubre además gestión de usuarios staff, clientes y mascotas, agenda multi-veterinario con detección de solapamientos (Schedule-X), perfil clínico completo de la mascota, historial clínico con adjuntos (imágenes/PDF), registro de vacunación, recordatorios automáticos de turno por email y auditoría inmutable de cambios y accesos sobre datos clínicos.
+The system also covers staff user management, clients and pets, a multi-veterinarian agenda with overlap detection (Schedule-X), the pet's complete clinical profile, clinical history with attachments (images/PDF), vaccination records, automatic appointment reminders by email and an immutable audit of changes and accesses to clinical data.
 
-> **Estado actual (junio 2026):** el proyecto pasó de la fase de documentación a un **MVP funcional**. Hay backend (FastAPI), frontend (Expo + Tamagui) y base de datos (PostgreSQL 16 con RLS) implementados y ejecutables localmente. Se completaron 24 pull requests sobre la rama `dev` (US-001 a US-014, US-017 a US-023 y US-DASH). El flujo diferenciador de IA (voz → campos clínicos) está operativo end-to-end.
+> **Current status (June 2026):** the project moved from the documentation phase to a **functional MVP**. There is a backend (FastAPI), frontend (Expo + Tamagui) and database (PostgreSQL 16 with RLS) implemented and runnable locally. 24 pull requests were completed onto the `dev` branch (US-001 to US-014, US-017 to US-023 and US-DASH). The differentiating AI flow (voice → clinical fields) is operational end-to-end.
 
-### **0.4. URL del proyecto:**
+### **0.4. Project URL:**
 
-> Producto aún no desplegado en producción (no hay URL pública). El MVP es **ejecutable localmente** con Docker Compose + los scripts `backend/start.ps1` y `frontend/start.ps1` (frontend en `http://localhost:8081`, backend en `http://localhost:8000`). El deploy en Railway está documentado pero pendiente de configurar.
+> Product not yet deployed to production (no public URL). The MVP is **runnable locally** with Docker Compose + the `backend/start.ps1` and `frontend/start.ps1` scripts (frontend at `http://localhost:8081`, backend at `http://localhost:8000`). The Railway deployment is documented but pending configuration.
 
-### 0.5. URL o archivo comprimido del repositorio
+### 0.5. Repository URL or compressed file
 
 https://github.com/mateocostes/Veterinary-Intelligence-Platform
 
-Branch principal: `main`. El desarrollo activo del MVP vive en la rama **`dev`** (24 PRs mergeados, `feat/us-XXX → dev`). La documentación técnica vive en `docs/`.
+Main branch: `main`. Active MVP development lives on the **`dev`** branch (24 merged PRs, `feat/us-XXX → dev`). The technical documentation lives in `docs/`.
 
 ---
 
-## 1. Descripción general del producto
+## 1. Product overview
 
-### **1.1. Objetivo:**
+### **1.1. Objective:**
 
-El producto resuelve un problema cuantificable de las clínicas veterinarias pequeñas: **la documentación clínica manual consume ~10 minutos por consulta**, tiempo que el veterinario no puede dedicar al paciente. La plataforma reduce ese tiempo estructurando automáticamente la historia clínica a partir de lo que el profesional dicta.
+The product solves a quantifiable problem of small veterinary clinics: **manual clinical documentation takes ~10 minutes per consultation**, time the veterinarian cannot dedicate to the patient. The platform reduces that time by automatically structuring the clinical record from what the professional dictates.
 
-**Valor por stakeholder:**
+**Value per stakeholder:**
 
-- **Veterinario:** graba una nota de voz mientras atiende; recibe los campos pre-completados con la información transcrita; revisa, edita lo que necesite y guarda con un click. Reduce la fricción administrativa.
-- **Recepcionista:** gestiona agenda multi-profesional sin solapamientos; el sistema dispara recordatorios automáticos de turno sin llamadas manuales.
-- **Administrador (dueño de la clínica, que suele también ejercer como veterinario):** gestiona el staff de la clínica; ve el perfil clínico completo de cada mascota; audita cambios sobre historias clínicas; controla quién accedió a qué información (cumplimiento Ley 25.326).
-- **Dueño de mascota:** recibe recordatorios automáticos por email; en Fase 1.5 accederá a un portal propio para consultar historial y autogestionar turnos.
+- **Veterinarian:** records a voice note while attending; receives the fields pre-filled with the transcribed information; reviews, edits what is needed and saves with one click. Reduces administrative friction.
+- **Receptionist:** manages a multi-professional agenda without overlaps; the system triggers automatic appointment reminders without manual calls.
+- **Administrator (clinic owner, who usually also practices as a veterinarian):** manages the clinic's staff; sees the complete clinical profile of each pet; audits changes to clinical records; controls who accessed what information (Law 25.326 compliance).
+- **Pet owner:** receives automatic email reminders; in Phase 1.5 will access their own portal to consult history and self-manage appointments.
 
-**Para quién:** clínicas veterinarias pequeñas argentinas de 1–5 veterinarios, donde el dueño suele también ejercer como profesional clínico, con eventual recepcionista, y con acceso a internet estable durante las consultas.
+**For whom:** small Argentine veterinary clinics of 1–5 veterinarians, where the owner usually also practices as a clinical professional, with an eventual receptionist, and with stable internet access during consultations.
 
-### **1.2. Características y funcionalidades principales:**
+### **1.2. Main features and functionalities:**
 
-| Feature | Estado | Descripción |
+| Feature | Status | Description |
 |---|---|---|
-| **Autenticación y multi-tenancy** | ✅ Implementado | Registro de clínica (crea Clinic + User admin atómicamente), login con JWT + refresh tokens en Redis, recuperación de contraseña por email, gestión de usuarios staff (Admin/Vet/Reception) con RBAC. Aislamiento entre clínicas con `clinic_id` + PostgreSQL Row-Level Security. |
-| **Historia Clínica Asistida por IA** | ✅ Implementado | Grabación de voz (MediaRecorder web) o subida de archivo de audio → transcripción con **Groq Whisper (`whisper-large-v3`)** → limpieza con **`claude-haiku-4-5`** → **estructuración** en los campos predefinidos con **`claude-sonnet-4-6`** (tool use + schema Pydantic `ClinicalRecordExtraction`, **prompt caching** activo). La IA extrae motivo, síntomas, peso, temperatura, medicación referida y —solo si el vet los dicta explícitamente— diagnóstico y tratamiento; **nunca los inventa**. Pipeline asíncrono vía ARQ con polling y fallback manual. Toda interacción IA queda auditada en `clinical_records_ai` (append-only). |
-| **Gestión de Clientes y Mascotas** | ✅ Implementado | CRUD de clientes y mascotas. Perfil clínico unificado de la mascota (datos básicos + últimas consultas + vacunas + próximos turnos). Búsqueda global por nombre de mascota o dueño con resultado enriquecido (mascota + dueño + próximo turno). |
-| **Agenda y Turnos** | ✅ Implementado | Vista diaria y semanal filtrable por veterinario (Schedule-X, español, anclada al lunes). Detección de solapamiento (HTTP 409). Reprogramar / cancelar (cancelación lógica que libera el horario). Marcar atendido (`pending → attended`) e iniciar/registrar la consulta desde el turno; ver/editar la consulta ya cargada (una por turno). |
-| **Adjuntos clínicos** | ✅ Implementado | Subida de imágenes/PDF (≤ 20 MB, máx. 10) a una consulta, validando el lote completo antes de subir. Almacenamiento en **Supabase Storage** (bucket privado `clinical-attachments`, URLs firmadas de corta vida). Grilla de miniaturas, apertura en pestaña nueva y borrado (soft delete auditado). |
-| **Vacunación** | ✅ Implementado | Registro de vacunas aplicadas con próxima fecha de vencimiento, opcionalmente vinculadas a una consulta. |
-| **Notificaciones Automáticas** | ✅ Implementado | Recordatorio de turno por email vía **SMTP (`aiosmtplib`)**, disparado por un **cron diario de Railway (`0 8 * * *`)** que avisa los turnos de mañana (un recordatorio, idempotente). Estado de cada envío visible en la agenda para admin/reception. |
-| **Auditoría y Trazabilidad** | ✅ Implementado | Registro automático e inmutable de mutaciones (`audit_log`, vía event listener de SQLAlchemy `after_flush`) y de accesos individuales a historias clínicas (`clinical_record_access_log`). Append-only enforced en motor (`REVOKE UPDATE, DELETE` al rol `app_runtime`). |
-| **Reportes** | 🟡 Parcial | Endpoints de reportes operativos/financieros y de auditoría en el backend; UI de reportes pendiente. |
+| **Authentication and multi-tenancy** | ✅ Implemented | Clinic registration (atomically creates Clinic + admin User), login with JWT + refresh tokens in Redis, password recovery by email, staff user management (Admin/Vet/Reception) with RBAC. Isolation between clinics with `clinic_id` + PostgreSQL Row-Level Security. |
+| **AI-Assisted Clinical Record** | ✅ Implemented | Voice recording (web MediaRecorder) or audio file upload → transcription with **Groq Whisper (`whisper-large-v3`)** → cleanup with **`claude-haiku-4-5`** → **structuring** into the predefined fields with **`claude-sonnet-4-6`** (tool use + Pydantic `ClinicalRecordExtraction` schema, **prompt caching** active). The AI extracts reason, symptoms, weight, temperature, referred medication and —only if the vet dictates them explicitly— diagnosis and treatment; **it never invents them**. Asynchronous pipeline via ARQ with polling and manual fallback. Every AI interaction is audited in `clinical_records_ai` (append-only). |
+| **Client and Pet Management** | ✅ Implemented | CRUD for clients and pets. Unified clinical profile of the pet (basic data + latest consultations + vaccines + upcoming appointments). Global search by pet or owner name with an enriched result (pet + owner + next appointment). |
+| **Agenda and Appointments** | ✅ Implemented | Daily and weekly view filterable by veterinarian (Schedule-X, Spanish, anchored to Monday). Overlap detection (HTTP 409). Reschedule / cancel (logical cancellation that frees the slot). Mark attended (`pending → attended`) and start/register the consultation from the appointment; view/edit the already loaded consultation (one per appointment). |
+| **Clinical attachments** | ✅ Implemented | Upload of images/PDF (≤ 20 MB, max 10) to a consultation, validating the whole batch before uploading. Storage in **Supabase Storage** (private bucket `clinical-attachments`, short-lived signed URLs). Thumbnail grid, opening in a new tab and deletion (audited soft delete). |
+| **Vaccination** | ✅ Implemented | Record of applied vaccines with the next due date, optionally linked to a consultation. |
+| **Automatic Notifications** | ✅ Implemented | Appointment reminder by email via **SMTP (`aiosmtplib`)**, triggered by a **daily Railway cron (`0 8 * * *`)** that notifies tomorrow's appointments (one reminder, idempotent). Status of each send visible in the agenda for admin/reception. |
+| **Audit and Traceability** | ✅ Implemented | Automatic and immutable recording of mutations (`audit_log`, via SQLAlchemy `after_flush` event listener) and of individual accesses to clinical records (`clinical_record_access_log`). Append-only enforced at the engine level (`REVOKE UPDATE, DELETE` on the `app_runtime` role). |
+| **Reports** | 🟡 Partial | Operational/financial and audit report endpoints in the backend; reports UI pending. |
 
-> **Features diferidos.**
-> - **Portal del Cliente (Fase 1.5):** autenticación independiente para dueños de mascotas; ver historial filtrable por veterinario y solicitar/cancelar turnos propios. Los emails de recordatorio ya enlazan a una landing pública informativa (`/appointments/{id}`); la acción real es Fase 1.5.
-> - **Soporte Offline (Fase 2):** Service Workers + IndexedDB con caché local y cola de mutaciones.
-> - **Generación de diagnósticos sugeridos con IA (Fase 2):** la IA del MVP solo estructura lo dictado; generar diagnósticos propios requiere validación clínica y regulatoria independiente.
-> - **Observabilidad completa (Fase 2):** Sentry + Pydantic Logfire / OpenTelemetry + PostHog. El MVP se sostiene con logging estructurado de FastAPI.
+> **Deferred features.**
+> - **Client Portal (Phase 1.5):** independent authentication for pet owners; view history filterable by veterinarian and request/cancel their own appointments. The reminder emails already link to an informational public landing (`/appointments/{id}`); the real action is Phase 1.5.
+> - **Offline Support (Phase 2):** Service Workers + IndexedDB with local cache and a mutation queue.
+> - **AI-generated suggested diagnoses (Phase 2):** the MVP's AI only structures what is dictated; generating its own diagnoses requires independent clinical and regulatory validation.
+> - **Full observability (Phase 2):** Sentry + Pydantic Logfire / OpenTelemetry + PostHog. The MVP relies on FastAPI structured logging.
 
-### **1.3. Diseño y experiencia de usuario:**
+### **1.3. Design and user experience:**
 
-La interfaz está implementada sobre el design system **"Clinical Serenity"** (extraído del proyecto Stitch `VetCare Digital Hub`), codificado como tokens semánticos de marca en `frontend/tamagui.config.ts` (`$brandPrimary` teal médico `#0d9488`, `$surface`, `$onSurface`, `$inputBorder`, `$radiusCard`…) y documentado en `docs/design-system.md`. La app monta `TamaguiProvider` con `defaultTheme="light"`. Cada componente consume **solo** estos tokens (regla R11), nunca hex crudos.
+The interface is implemented over the **"Clinical Serenity"** design system (extracted from the Stitch project `VetCare Digital Hub`), codified as semantic brand tokens in `frontend/tamagui.config.ts` (`$brandPrimary` medical teal `#0d9488`, `$surface`, `$onSurface`, `$inputBorder`, `$radiusCard`…) and documented in `docs/design-system.md`. The app mounts `TamaguiProvider` with `defaultTheme="light"`. Each component consumes **only** these tokens (rule R11), never raw hex.
 
-Flujos principales implementados:
+Main flows implemented:
 
-- **Dashboard por rol:** tarjetas de navegación con visibilidad según rol (admin/vet/reception), saludo dinámico y barra de búsqueda global.
-- **Flujo de consulta con IA:** turno → "Marcar atendido" → "Registrar consulta" → grabar/subir audio → indicador de procesamiento → formulario pre-llenado con los campos extraídos → editar → guardar (con opción de adjuntar archivos).
-- **Flujo de agenda:** calendario Schedule-X día/semana → filtro por veterinario → "Nuevo turno" (búsqueda de mascota + selección de vet, detección de solapamiento) → click en un turno pendiente para reprogramar/cancelar.
-- **Perfil de mascota:** datos básicos + historial clínico (acordeón paginado) + vacunas + próximos turnos.
+- **Dashboard per role:** navigation cards with role-based visibility (admin/vet/reception), dynamic greeting and a global search bar.
+- **AI consultation flow:** appointment → "Mark attended" → "Register consultation" → record/upload audio → processing indicator → form pre-filled with the extracted fields → edit → save (with the option to attach files).
+- **Agenda flow:** Schedule-X day/week calendar → filter by veterinarian → "New appointment" (pet search + vet selection, overlap detection) → click a pending appointment to reschedule/cancel.
+- **Pet profile:** basic data + clinical history (paginated accordion) + vaccines + upcoming appointments.
 
-> **Capturas:** la UI es funcional y verificada manualmente en navegador a lo largo del desarrollo (ver `docs/changelog/US-*.md`). Las capturas formales se agregarán en la próxima iteración de documentación.
+> **Screenshots:** the UI is functional and manually verified in the browser throughout development (see `docs/changelog/US-*.md`). Formal screenshots will be added in the next documentation iteration.
 
-### **1.4. Instrucciones de instalación:**
+### **1.4. Installation instructions:**
 
-**Infraestructura local (Docker):**
+**Local infrastructure (Docker):**
 ```powershell
-docker-compose up -d postgres redis     # PostgreSQL 16 + Redis 7 (ambos healthy)
+docker-compose up -d postgres redis     # PostgreSQL 16 + Redis 7 (both healthy)
 ```
 
 **Backend (FastAPI):**
 ```powershell
-.\backend\start.ps1    # crea venv + instala deps + aplica migraciones + uvicorn (lee .env de la raíz)
-# Worker ARQ (para el flujo IA):
+.\backend\start.ps1    # creates venv + installs deps + applies migrations + uvicorn (reads .env from the root)
+# ARQ Worker (for the AI flow):
 .\.venv\Scripts\python.exe -m arq app.worker.settings.WorkerSettings
 ```
 
 **Frontend (Expo web):**
 ```powershell
-.\frontend\start.ps1   # instala deps si faltan + expo start --web (http://localhost:8081)
+.\frontend\start.ps1   # installs deps if missing + expo start --web (http://localhost:8081)
 ```
 
-**Variables de entorno (`.env` en la raíz, ver `.env.example`):** `DATABASE_URL` / `DATABASE_URL_SYNC`, `JWT_SECRET`, `SMTP_*` (host/port/user/password/from), `GROQ_API_KEY` (Whisper), `ANTHROPIC_API_KEY` (Claude), `SUPABASE_URL` / `SUPABASE_KEY` (adjuntos). Las migraciones (Alembic `0001`–`0011`) crean el schema, activan Row-Level Security y aplican los GRANTs append-only sobre `audit_log` / `clinical_record_access_log` / `clinical_records_ai`.
+**Environment variables (`.env` in the root, see `.env.example`):** `DATABASE_URL` / `DATABASE_URL_SYNC`, `JWT_SECRET`, `SMTP_*` (host/port/user/password/from), `GROQ_API_KEY` (Whisper), `ANTHROPIC_API_KEY` (Claude), `SUPABASE_URL` / `SUPABASE_KEY` (attachments). The migrations (Alembic `0001`–`0011`) create the schema, enable Row-Level Security and apply the append-only GRANTs on `audit_log` / `clinical_record_access_log` / `clinical_records_ai`.
 
 **Tests:**
 ```powershell
@@ -122,35 +122,35 @@ Set-Location e2e; npx playwright test --project=chromium
 
 ---
 
-## 2. Arquitectura del Sistema
+## 2. System Architecture
 
-### **2.1. Diagrama de arquitectura:**
+### **2.1. Architecture diagram:**
 
-La arquitectura sigue un patrón de tres capas desacopladas: frontend (Expo + React Native Web), backend API REST (FastAPI) y base de datos relacional (PostgreSQL). Los servicios de IA y email se consumen como APIs externas. El almacenamiento de archivos es independiente de la base de datos. **Todos los servicios se planifican en un único proyecto de Railway** para simplificar la operación y eliminar CORS interno.
+The architecture follows a three decoupled-layer pattern: frontend (Expo + React Native Web), REST API backend (FastAPI) and relational database (PostgreSQL). The AI and email services are consumed as external APIs. File storage is independent of the database. **All services are planned in a single Railway project** to simplify operations and eliminate internal CORS.
 
 ```mermaid
 flowchart TD
-  subgraph Client["Cliente (Browser / iOS / Android)"]
+  subgraph Client["Client (Browser / iOS / Android)"]
     FE["Expo Router + Tamagui<br/>React Native Web (web)<br/>Schedule-X · TanStack Table"]
   end
 
   subgraph Railway["Railway project (single)"]
     STATIC["Frontend (Static — nginx)"]
-    API["FastAPI Backend<br/>Auth (JWT) · Business Logic · AI Orchestration<br/>+ PostgreSQL RLS por sesión"]
-    ARQ["ARQ Worker<br/>(pipeline IA async)"]
-    CRON["Cron job diario<br/>send_appointment_reminders.py (0 8 * * *)"]
-    RED["Redis managed<br/>(broker ARQ + refresh tokens + task results)"]
+    API["FastAPI Backend<br/>Auth (JWT) · Business Logic · AI Orchestration<br/>+ PostgreSQL RLS per session"]
+    ARQ["ARQ Worker<br/>(async AI pipeline)"]
+    CRON["Daily cron job<br/>send_appointment_reminders.py (0 8 * * *)"]
+    RED["Redis managed<br/>(ARQ broker + refresh tokens + task results)"]
     PG["PostgreSQL 16 managed<br/>Multi-tenancy + Row-Level Security<br/>+ audit_log append-only"]
   end
 
-  subgraph Storage["Almacenamiento de archivos"]
-    S3["Supabase Storage<br/>(bucket privado clinical-attachments)"]
+  subgraph Storage["File storage"]
+    S3["Supabase Storage<br/>(private bucket clinical-attachments)"]
   end
 
-  subgraph External["APIs Externas"]
-    WHISPER["Groq Whisper API<br/>whisper-large-v3 (transcripción)"]
+  subgraph External["External APIs"]
+    WHISPER["Groq Whisper API<br/>whisper-large-v3 (transcription)"]
     CLAUDE["Claude API (Anthropic)<br/>haiku-4-5 cleanup + sonnet-4-6 tool use"]
-    SMTP["SMTP (aiosmtplib)<br/>emails transaccionales"]
+    SMTP["SMTP (aiosmtplib)<br/>transactional emails"]
   end
 
   FE -->|HTTPS| STATIC
@@ -165,83 +165,83 @@ flowchart TD
   CRON --> SMTP
 ```
 
-*Figure 1: Diagrama de arquitectura general del sistema*
+*Figure 1: General system architecture diagram*
 
-**Patrón elegido:** Arquitectura de tres capas (Presentation / Application / Data) con orquestación async desacoplada (ARQ) para el pipeline de IA y un cron diario de Railway para los recordatorios. Multi-tenancy con **defensa en profundidad**: filtro por `clinic_id` en queries SQLAlchemy + PostgreSQL Row-Level Security como segunda capa en motor.
+**Chosen pattern:** Three-layer architecture (Presentation / Application / Data) with decoupled async orchestration (ARQ) for the AI pipeline and a daily Railway cron for reminders. Multi-tenancy with **defense in depth**: filter by `clinic_id` in SQLAlchemy queries + PostgreSQL Row-Level Security as a second layer at the engine.
 
-**Justificación:**
-- **FastAPI + PostgreSQL** proveen un backend tipado, async-nativo y de alta performance. Pydantic v2 hace que el schema de extracción (`ClinicalRecordExtraction`) sirva simultáneamente como tool_use schema para Claude y como shape del JSONB en `clinical_records_ai`.
-- **Expo (Expo Router + Tamagui)** con build web vía React Native Web comparte la UI entre web y móvil desde el primer componente — las capas `services/` y `store/` se portan sin reescritura.
-- **ARQ** desacopla el pipeline de IA (latencia variable de Whisper + 2 llamadas a Claude) de la respuesta HTTP. Async-nativo, mismo Redis que ya se usa para refresh tokens — sin agregar Celery.
-- **PostgreSQL Row-Level Security** en cada tabla con `clinic_id`: si una query omite el filtro, el motor devuelve cero filas en lugar de filtrar entre clínicas. La fuga de datos clínicos entre tenants se vuelve imposible a nivel de motor.
-- **Railway-solo** elimina la fricción operativa de dos clouds (sin CORS, sin duplicación de envs).
+**Justification:**
+- **FastAPI + PostgreSQL** provide a typed, async-native, high-performance backend. Pydantic v2 makes the extraction schema (`ClinicalRecordExtraction`) serve simultaneously as the tool_use schema for Claude and as the shape of the JSONB in `clinical_records_ai`.
+- **Expo (Expo Router + Tamagui)** with a web build via React Native Web shares the UI between web and mobile from the very first component — the `services/` and `store/` layers are ported without a rewrite.
+- **ARQ** decouples the AI pipeline (variable Whisper latency + 2 Claude calls) from the HTTP response. Async-native, the same Redis already used for refresh tokens — without adding Celery.
+- **PostgreSQL Row-Level Security** on each table with `clinic_id`: if a query omits the filter, the engine returns zero rows instead of leaking across clinics. Clinical data leakage between tenants becomes impossible at the engine level.
+- **Railway-only** eliminates the operational friction of two clouds (no CORS, no env duplication).
 
-**Trade-offs y decisiones de implementación:**
-- **Groq Whisper en lugar de OpenAI `whisper-1`:** se adoptó Groq (`whisper-large-v3`, vía SDK de OpenAI con `base_url` override) por su capa gratuita sin tarjeta, suficiente para el desarrollo del MVP. Cambiar de proveedor es config.
-- **SMTP (`aiosmtplib`) en lugar de Resend:** se migró en US-004 para entregar a cualquier destinatario sin verificar dominio (App Password de Gmail en dev; SES/Mailgun/Brevo en prod). Config-only para cambiar de proveedor.
-- **RLS agrega complejidad de setup:** dos usuarios de DB (`app_runtime` con RLS forzado, `app_admin` con `BYPASSRLS` para Alembic) + `set_config('app.clinic_id', …, true)` por request (se usa `set_config`, no `SET LOCAL`, porque Postgres no acepta parámetros vinculados en `SET`).
-- **Soporte offline diferido a Fase 2:** el MVP asume conectividad estable.
+**Trade-offs and implementation decisions:**
+- **Groq Whisper instead of OpenAI `whisper-1`:** Groq was adopted (`whisper-large-v3`, via the OpenAI SDK with a `base_url` override) for its free tier without a card, sufficient for MVP development. Changing providers is config.
+- **SMTP (`aiosmtplib`) instead of Resend:** migrated in US-004 to deliver to any recipient without verifying a domain (Gmail App Password in dev; SES/Mailgun/Brevo in prod). Config-only to change providers.
+- **RLS adds setup complexity:** two DB users (`app_runtime` with forced RLS, `app_admin` with `BYPASSRLS` for Alembic) + `set_config('app.clinic_id', …, true)` per request (`set_config` is used, not `SET LOCAL`, because Postgres does not accept bound parameters in `SET`).
+- **Offline support deferred to Phase 2:** the MVP assumes stable connectivity.
 
-### **2.2. Descripción de componentes principales:**
+### **2.2. Description of main components:**
 
-| Componente | Tecnología | Responsabilidad |
+| Component | Technology | Responsibility |
 |---|---|---|
-| **Frontend** | React 18 + TypeScript, Expo Router + Tamagui, Zustand, TanStack Query, axios | UI web (y móvil compartida), estado local/servidor, grabación de audio (MediaRecorder web) |
-| **Frontend — agenda** | Schedule-X v2 | Vista día/semana, navegación por semana (anclada al lunes), filtro por veterinario, click en turno → reprogramar/cancelar |
-| **Frontend — data grids** | TanStack Table v8 | Listados (usuarios, clientes, mascotas) con orden y filtro |
-| **Backend API** | Python 3.12, FastAPI, Pydantic v2 | REST API con validación, RBAC por rol (JWT), orquestación de servicios IA |
-| **ORM / Migraciones** | SQLAlchemy 2.0 (async), Alembic | Acceso async tipado; migraciones `0001`–`0011`. Migraciones con `app_admin`; queries de la app con `app_runtime` (RLS forzado) |
-| **Worker asíncrono** | ARQ + Redis | Pipeline IA (Groq Whisper → Haiku cleanup → Sonnet extracción → audit en DB) sin bloquear la respuesta HTTP. Crea su propia sesión con `set_config` para RLS |
-| **Tarea programada** | Cron diario de Railway | `python -m app.jobs.send_appointment_reminders` (`0 8 * * *`); también invocable vía endpoint interno con API key |
-| **Base de datos** | PostgreSQL 16 | Multi-tenancy `clinic_id` + RLS, soft delete, JSONB para output IA, tablas append-only de auditoría |
-| **Object Storage** | Supabase Storage (Strategy `supabase`\|`s3`) | Adjuntos clínicos en bucket privado `clinical-attachments` con URLs firmadas (≤ 1h). Facade `StorageService` inyectable y mockeable |
-| **Transcripción** | Groq (`whisper-large-v3`) | Audio → texto, procesado de forma asíncrona vía ARQ |
-| **Estructuración IA** | Anthropic — `claude-haiku-4-5` (cleanup) + `claude-sonnet-4-6` (tool use + Vision a futuro) | Estructuración de la historia clínica vía tool use + schema Pydantic. Prompt caching (`cache_control: ephemeral`). No inventa diagnósticos |
-| **Email** | SMTP vía `aiosmtplib` | Recordatorios de turno y recuperación de contraseña (multipart texto+HTML, timeout 30s, fallos swalloweados anti-enumeración) |
+| **Frontend** | React 18 + TypeScript, Expo Router + Tamagui, Zustand, TanStack Query, axios | Web UI (and shared mobile), local/server state, audio recording (web MediaRecorder) |
+| **Frontend — agenda** | Schedule-X v2 | Day/week view, weekly navigation (anchored to Monday), filter by veterinarian, click an appointment → reschedule/cancel |
+| **Frontend — data grids** | TanStack Table v8 | Listings (users, clients, pets) with sorting and filtering |
+| **Backend API** | Python 3.12, FastAPI, Pydantic v2 | REST API with validation, role-based RBAC (JWT), orchestration of AI services |
+| **ORM / Migrations** | SQLAlchemy 2.0 (async), Alembic | Typed async access; migrations `0001`–`0011`. Migrations with `app_admin`; app queries with `app_runtime` (forced RLS) |
+| **Async worker** | ARQ + Redis | AI pipeline (Groq Whisper → Haiku cleanup → Sonnet extraction → DB audit) without blocking the HTTP response. Creates its own session with `set_config` for RLS |
+| **Scheduled task** | Daily Railway cron | `python -m app.jobs.send_appointment_reminders` (`0 8 * * *`); also invokable via an internal endpoint with an API key |
+| **Database** | PostgreSQL 16 | Multi-tenancy `clinic_id` + RLS, soft delete, JSONB for AI output, append-only audit tables |
+| **Object Storage** | Supabase Storage (Strategy `supabase`\|`s3`) | Clinical attachments in the private bucket `clinical-attachments` with signed URLs (≤ 1h). Injectable and mockable `StorageService` facade |
+| **Transcription** | Groq (`whisper-large-v3`) | Audio → text, processed asynchronously via ARQ |
+| **AI structuring** | Anthropic — `claude-haiku-4-5` (cleanup) + `claude-sonnet-4-6` (tool use + Vision in the future) | Clinical record structuring via tool use + Pydantic schema. Prompt caching (`cache_control: ephemeral`). Does not invent diagnoses |
+| **Email** | SMTP via `aiosmtplib` | Appointment reminders and password recovery (multipart text+HTML, 30s timeout, failures swallowed anti-enumeration) |
 
-### **2.3. Descripción de alto nivel del proyecto y estructura de ficheros**
+### **2.3. High-level project description and file structure**
 
-Organización monorepo con separación frontend/backend:
+Monorepo organization with frontend/backend separation:
 
 ```
 /
 ├── frontend/                 # Expo + React Native Web
 │   └── src/
-│       ├── app/              # Router (Expo Router): (app) protegido, (auth), rutas públicas
-│       ├── features/         # Módulos por dominio (auth, users, clients, pets,
+│       ├── app/              # Router (Expo Router): (app) protected, (auth), public routes
+│       ├── features/         # Domain modules (auth, users, clients, pets,
 │       │                     #   clinical-records, appointments, vaccinations,
 │       │                     #   ai-assistant, dashboard, …)
-│       ├── shared/           # Componentes Tamagui, hooks y utils reutilizables
-│       ├── services/         # Clientes HTTP por módulo (axios + interceptor JWT/refresh)
-│       └── store/            # Stores de Zustand (persist web/native)
+│       ├── shared/           # Reusable Tamagui components, hooks and utils
+│       ├── services/         # HTTP clients per module (axios + JWT/refresh interceptor)
+│       └── store/            # Zustand stores (persist web/native)
 │
 ├── backend/                  # FastAPI application
 │   └── app/
-│       ├── core/             # Config, security, deps (set_config app.clinic_id para RLS)
+│       ├── core/             # Config, security, deps (set_config app.clinic_id for RLS)
 │       ├── api/v1/endpoints/ # auth, users, clients, pets, appointments,
 │       │                     #   clinical_records, vaccinations, search, ai,
 │       │                     #   reports, audit, internal
-│       ├── models/           # SQLAlchemy 2.0 con Timestamp/SoftDelete/Tenant mixins
+│       ├── models/           # SQLAlchemy 2.0 with Timestamp/SoftDelete/Tenant mixins
 │       ├── schemas/          # Pydantic (request/response + ClinicalRecordExtraction)
-│       ├── crud/             # Operaciones de base de datos
+│       ├── crud/             # Database operations
 │       ├── services/         # ai_service, notification_service, audit_logger, storage
-│       ├── worker/           # ARQ worker (settings + tasks del pipeline IA)
-│       ├── jobs/             # send_appointment_reminders (cron diario)
-│       └── alembic/          # Migraciones 0001–0011
+│       ├── worker/           # ARQ worker (settings + AI pipeline tasks)
+│       ├── jobs/             # send_appointment_reminders (daily cron)
+│       └── alembic/          # Migrations 0001–0011
 │
-├── e2e/                      # Playwright (auth, agenda, flujo IA)
-├── docs/                     # Documentación técnica + changelog/US-XXX.md + prompts
-├── entrega1/ · entrega2/     # Artefactos de las entregas del curso
-├── ia-agents/                # Agentes/skills/rules custom para asistencia de IA
-├── docker-compose.yml        # Entorno de desarrollo local
-└── CLAUDE.md                 # Contexto del proyecto para asistentes de IA
+├── e2e/                      # Playwright (auth, agenda, AI flow)
+├── docs/                     # Technical documentation + changelog/US-XXX.md + prompts
+├── entrega1/ · entrega2/     # Course delivery artifacts
+├── ia-agents/                # Custom agents/skills/rules for AI assistance
+├── docker-compose.yml        # Local development environment
+└── CLAUDE.md                 # Project context for AI assistants
 ```
 
-Patrón: **feature-based** en el frontend, **layered** en el backend (api → services/crud → models). Las capas `services/` y `store/` se comparten directamente entre web y móvil gracias a Expo.
+Pattern: **feature-based** on the frontend, **layered** on the backend (api → services/crud → models). The `services/` and `store/` layers are shared directly between web and mobile thanks to Expo.
 
-### **2.4. Infraestructura y despliegue**
+### **2.4. Infrastructure and deployment**
 
-Todos los servicios se planifican en un único proyecto de **Railway**. El deploy está documentado (`backend/railway.cron.json` define el cron diario) pero aún no configurado; el desarrollo y la validación ocurren en local (Docker Compose).
+All services are planned in a single **Railway** project. The deployment is documented (`backend/railway.cron.json` defines the daily cron) but not yet configured; development and validation happen locally (Docker Compose).
 
 ```mermaid
 flowchart TD
@@ -250,7 +250,7 @@ flowchart TD
     STATIC["Frontend (Static Site)"]
     BACKEND["Backend (Docker — FastAPI)"]
     WORKER["ARQ Worker (Docker)"]
-    CRON["Cron diario (0 8 * * *)"]
+    CRON["Daily cron (0 8 * * *)"]
     PG["PostgreSQL managed"]
     REDIS["Redis managed"]
   end
@@ -263,49 +263,49 @@ flowchart TD
   CRON --> PG
 ```
 
-*Figure 2: Pipeline de infraestructura y despliegue (planificado)*
+*Figure 2: Infrastructure and deployment pipeline (planned)*
 
-| Entorno | Branch | Propósito |
+| Environment | Branch | Purpose |
 |---|---|---|
-| Development | `dev` | Desarrollo activo (Docker Compose local); 24 PRs `feat/us-XXX → dev` |
-| Production | `main` | Clínicas reales (deploy pendiente) |
+| Development | `dev` | Active development (local Docker Compose); 24 PRs `feat/us-XXX → dev` |
+| Production | `main` | Real clinics (deployment pending) |
 
-> **Nota sobre el flujo de git/board:** cada US se desarrolla en `feat/us-XXX` desde `dev`, con un commit por ticket (`feat(db|be|fe):`) y un PR a `dev` (`Closes #N`). El GitHub Project board recorre Todo → In Progress → In Review → Done. Como el PR apunta a `dev` (no a `main`), el `Closes #N` no auto-cierra al mergear a `dev`: el paso a Done es manual.
+> **Note on the git/board flow:** each US is developed on `feat/us-XXX` from `dev`, with one commit per ticket (`feat(db|be|fe):`) and a PR to `dev` (`Closes #N`). The GitHub Project board moves through Todo → In Progress → In Review → Done. Since the PR targets `dev` (not `main`), the `Closes #N` does not auto-close on merge to `dev`: moving to Done is manual.
 
-**Costo estimado mensual (MVP de pocos usuarios):** ~U$ 55–70/mes en Railway-solo (la transcripción usa la capa gratuita de Groq; Claude con prompt caching es marginal a este volumen).
+**Estimated monthly cost (few-user MVP):** ~US$ 55–70/month on Railway-only (transcription uses Groq's free tier; Claude with prompt caching is marginal at this volume).
 
-### **2.5. Seguridad**
+### **2.5. Security**
 
-- **HTTPS obligatorio** (TLS gestionado por Railway en prod).
-- **Autenticación JWT con refresh tokens:** access token de corta duración firmado con HMAC; refresh tokens en Redis con rotación. Payload: `{ user_id, clinic_id, role, exp }`. Índice inverso `user_refresh:{user_id}` para revocar todas las sesiones de un usuario al recuperar contraseña.
-- **Multi-tenancy con defensa en profundidad:** filtro por `clinic_id` en cada query **+ PostgreSQL Row-Level Security**. La sesión ejecuta `SELECT set_config('app.clinic_id', :cid, true)` al abrirse; las policies filtran por `current_setting('app.clinic_id')::uuid`. El usuario `app_runtime` tiene `FORCE ROW LEVEL SECURITY`.
-- **Anti-enumeración:** `forgot-password` siempre responde 200; login corre bcrypt contra un hash dummy si el usuario no existe (cierra el timing-oracle); accesos cruzados a recursos de otra clínica devuelven 404, no 403.
-- **Rate limiting / headers de seguridad:** planificados como middleware en FastAPI.
-- **Cifrado en reposo** (Postgres + Storage managed) y **URLs de archivos firmadas** (≤ 1h) para adjuntos.
-- **Soft delete:** los registros clínicos nunca se eliminan físicamente. Excepción: los turnos se cancelan como cambio de estado (`status='cancelled'` + `cancelled_at`/`cancelled_by`/`cancellation_reason`), no con `deleted_at`, para liberar el horario.
-- **Auditoría completa:**
-  - `audit_log` registra todas las mutaciones (create/update/delete/restore + acciones explícitas como `status_change`, `attachment_added`) sobre tablas tenant-scoped, vía event listener de SQLAlchemy `after_flush`. Diff old/new en JSONB.
-  - `clinical_record_access_log` registra cada lectura individual de una historia clínica.
-  - **Append-only enforced en DB:** `REVOKE UPDATE, DELETE … FROM app_runtime`.
-- **Auditoría de IA:** toda interacción con Whisper y Claude se almacena en `clinical_records_ai` (input, transcripción, prompt completo, schema, output estructurado, modelo, tokens de cache, tiempo). Tabla append-only.
+- **Mandatory HTTPS** (TLS managed by Railway in prod).
+- **JWT authentication with refresh tokens:** short-lived access token signed with HMAC; refresh tokens in Redis with rotation. Payload: `{ user_id, clinic_id, role, exp }`. Reverse index `user_refresh:{user_id}` to revoke all of a user's sessions on password recovery.
+- **Multi-tenancy with defense in depth:** filter by `clinic_id` in every query **+ PostgreSQL Row-Level Security**. The session runs `SELECT set_config('app.clinic_id', :cid, true)` on opening; the policies filter by `current_setting('app.clinic_id')::uuid`. The `app_runtime` user has `FORCE ROW LEVEL SECURITY`.
+- **Anti-enumeration:** `forgot-password` always responds 200; login runs bcrypt against a dummy hash if the user does not exist (closes the timing oracle); cross accesses to another clinic's resources return 404, not 403.
+- **Rate limiting / security headers:** planned as FastAPI middleware.
+- **Encryption at rest** (managed Postgres + Storage) and **signed file URLs** (≤ 1h) for attachments.
+- **Soft delete:** clinical records are never physically deleted. Exception: appointments are cancelled as a state change (`status='cancelled'` + `cancelled_at`/`cancelled_by`/`cancellation_reason`), not with `deleted_at`, to free the slot.
+- **Full audit:**
+  - `audit_log` records all mutations (create/update/delete/restore + explicit actions like `status_change`, `attachment_added`) on tenant-scoped tables, via the SQLAlchemy `after_flush` event listener. Old/new diff in JSONB.
+  - `clinical_record_access_log` records each individual read of a clinical record.
+  - **Append-only enforced in DB:** `REVOKE UPDATE, DELETE … FROM app_runtime`.
+- **AI audit:** every interaction with Whisper and Claude is stored in `clinical_records_ai` (input, transcription, full prompt, schema, structured output, model, cache tokens, time). Append-only table.
 
 ### **2.6. Tests**
 
-| Tipo | Tecnología | Cobertura |
+| Type | Technology | Coverage |
 |---|---|---|
-| **Unitarios + integración (backend)** | pytest + pytest-asyncio (engine aiosqlite, rollback por test, `AsyncClient`) | Endpoints, CRUD, RLS, migraciones, append-only. Suite > 570 tests al cierre de US-010 |
-| **Snapshot del prompt IA** | syrupy | Bloquea el merge si el system prompt o el schema enviado a Claude cambian sin actualizar el snapshot |
-| **Aislamiento multi-tenant + append-only** | pytest (suite custom) | Verifica aislamiento entre clínicas y que `UPDATE`/`DELETE` sobre `audit_log` desde `app_runtime` falle con error de permisos de Postgres |
-| **Frontend** | Jest + React Native Testing Library (mock de Tamagui/Expo Router/Zustand/TanStack Query) | Componentes, hooks, formularios, máscaras de entrada. Suite > 400 tests |
-| **E2E del flujo crítico** | Playwright (chromium) | Registro, login (redirección por rol + persistencia), agenda (ver/togglear/filtrar/crear turno), flujo IA |
+| **Unit + integration (backend)** | pytest + pytest-asyncio (aiosqlite engine, rollback per test, `AsyncClient`) | Endpoints, CRUD, RLS, migrations, append-only. Suite > 570 tests at the close of US-010 |
+| **AI prompt snapshot** | syrupy | Blocks the merge if the system prompt or the schema sent to Claude changes without updating the snapshot |
+| **Multi-tenant isolation + append-only** | pytest (custom suite) | Verifies isolation between clinics and that `UPDATE`/`DELETE` on `audit_log` from `app_runtime` fails with a Postgres permission error |
+| **Frontend** | Jest + React Native Testing Library (mocking Tamagui/Expo Router/Zustand/TanStack Query) | Components, hooks, forms, input masks. Suite > 400 tests |
+| **E2E of the critical flow** | Playwright (chromium) | Registration, login (role-based redirection + persistence), agenda (view/toggle/filter/create appointment), AI flow |
 
 ---
 
-## 3. Modelo de Datos
+## 3. Data Model
 
-### **3.1. Diagrama del modelo de datos:**
+### **3.1. Data model diagram:**
 
-Todas las entidades están implementadas vía migraciones Alembic `0001`–`0011`, con `clinic_id` + RLS forzada en las tablas tenant-scoped.
+All entities are implemented via Alembic migrations `0001`–`0011`, with `clinic_id` + forced RLS on tenant-scoped tables.
 
 ```mermaid
 erDiagram
@@ -356,8 +356,8 @@ erDiagram
     string phone
     text address
     text notes
-    boolean portal_enabled "Fase 1.5"
-    string password_hash "Fase 1.5"
+    boolean portal_enabled "Phase 1.5"
+    string password_hash "Phase 1.5"
     timestamptz deleted_at
   }
 
@@ -366,7 +366,7 @@ erDiagram
     uuid clinic_id FK
     uuid client_id FK
     string name
-    string species "texto libre"
+    string species "free text"
     string breed
     date birthdate
     string sex
@@ -408,8 +408,8 @@ erDiagram
     uuid created_by FK
     text consultation_reason
     text symptoms
-    text diagnosis "vet (manual o dictado a la IA)"
-    text treatment "vet (manual o dictado a la IA)"
+    text diagnosis "vet (manual or dictated to the AI)"
+    text treatment "vet (manual or dictated to the AI)"
     text medication
     decimal weight_kg
     decimal temperature_c
@@ -420,7 +420,7 @@ erDiagram
     uuid id PK
     uuid clinic_id FK
     uuid clinical_record_id FK
-    text file_url "storage key canónico"
+    text file_url "canonical storage key"
     string file_name
     string file_type
     int file_size_bytes
@@ -464,7 +464,7 @@ erDiagram
     string action "create | update | delete | status_change | attachment_added"
     uuid changed_by_user_id
     inet actor_ip
-    jsonb changes "diff old/new"
+    jsonb changes "old/new diff"
     timestamptz changed_at
   }
 
@@ -480,43 +480,43 @@ erDiagram
   }
 ```
 
-*Figure 3: Diagrama ER del modelo de datos del MVP implementado (Fase 1) + campos de Portal del Cliente en `clients` reservados para Fase 1.5*
+*Figure 3: ER diagram of the implemented MVP data model (Phase 1) + Client Portal fields in `clients` reserved for Phase 1.5*
 
-### **3.2. Descripción de entidades principales:**
+### **3.2. Description of main entities:**
 
-**Convenciones globales:** UUID como PK; `created_at`/`updated_at` en todas las tablas; soft delete con `deleted_at` en modelos clínicos y de negocio (excepto `appointments`, que usa cambio de estado); `clinic_id` con RLS habilitado en cada tabla tenant-scoped.
+**Global conventions:** UUID as PK; `created_at`/`updated_at` on all tables; soft delete with `deleted_at` on clinical and business models (except `appointments`, which uses a state change); `clinic_id` with RLS enabled on each tenant-scoped table.
 
-- **`clinics`** — entidad raíz del multi-tenancy. Incluye `timezone` (IANA) para localizar la hora de los recordatorios.
-- **`users`** — staff (Admin/Vet/Reception) con JWT propio; email único por clínica; `last_login_at`.
-- **`clients`** — dueños de mascotas. Los campos de Portal (`portal_enabled`, `password_hash`…) están reservados para Fase 1.5.
-- **`pets`** — pacientes; `species` es texto libre (selector con opción "Otro"); `neutered` boolean.
-- **`appointments`** — turnos; índice para detección de solapamiento; cancelación lógica (`status='cancelled'` + campos asociados) que libera el horario (`has_overlap` y el listado filtran `status != 'cancelled'`).
-- **`clinical_records`** — núcleo del sistema; soft delete; editable (auditado), una historia activa por turno (guard 409).
-- **`clinical_records_ai`** — auditoría append-only del pipeline IA (input, transcripción, prompt, schema, output, modelo, tokens de cache, tiempo).
-- **`clinical_attachments`** — adjuntos (tenant-scoped + RLS); `file_url` es la storage key canónica; la signed URL se resuelve por respuesta.
-- **`vaccinations`** — vacunas aplicadas con próxima fecha; vínculo opcional a una consulta.
-- **`appointment_notifications`** — sin `clinic_id` (aislamiento vía `appointment_id`); índice UNIQUE parcial `(appointment_id, trigger_hours_before) WHERE status='sent'` para idempotencia.
-- **`audit_log` / `clinical_record_access_log`** — append-only enforced en motor (`REVOKE UPDATE, DELETE`); retención 7 años + anonimización ante derecho al olvido.
+- **`clinics`** — multi-tenancy root entity. Includes `timezone` (IANA) to localize the reminder time.
+- **`users`** — staff (Admin/Vet/Reception) with their own JWT; unique email per clinic; `last_login_at`.
+- **`clients`** — pet owners. The Portal fields (`portal_enabled`, `password_hash`…) are reserved for Phase 1.5.
+- **`pets`** — patients; `species` is free text (selector with an "Other" option); `neutered` boolean.
+- **`appointments`** — appointments; index for overlap detection; logical cancellation (`status='cancelled'` + associated fields) that frees the slot (`has_overlap` and the listing filter `status != 'cancelled'`).
+- **`clinical_records`** — system core; soft delete; editable (audited), one active record per appointment (409 guard).
+- **`clinical_records_ai`** — append-only audit of the AI pipeline (input, transcription, prompt, schema, output, model, cache tokens, time).
+- **`clinical_attachments`** — attachments (tenant-scoped + RLS); `file_url` is the canonical storage key; the signed URL is resolved per response.
+- **`vaccinations`** — applied vaccines with the next date; optional link to a consultation.
+- **`appointment_notifications`** — without `clinic_id` (isolation via `appointment_id`); partial UNIQUE index `(appointment_id, trigger_hours_before) WHERE status='sent'` for idempotency.
+- **`audit_log` / `clinical_record_access_log`** — append-only enforced at the engine (`REVOKE UPDATE, DELETE`); 7-year retention + anonymization on right-to-be-forgotten.
 
-> **Entidades de Fase 2** (no implementadas): `services`, `payments`, `inventory_items`.
+> **Phase 2 entities** (not implemented): `services`, `payments`, `inventory_items`.
 
 ---
 
-## 4. Especificación de la API
+## 4. API Specification
 
-Endpoints implementados (selección representativa). Todos requieren JWT con `clinic_id` salvo los públicos (`/auth/*`, landing de turno) y el interno (API key). Multi-tenancy reforzada con RLS.
+Implemented endpoints (representative selection). All require a JWT with `clinic_id` except the public ones (`/auth/*`, appointment landing) and the internal one (API key). Multi-tenancy reinforced with RLS.
 
-**Autenticación** — `POST /auth/register`, `POST /auth/login`, `POST /auth/refresh`, `POST /auth/logout`, `POST /auth/forgot-password`, `POST /auth/reset-password`.
+**Authentication** — `POST /auth/register`, `POST /auth/login`, `POST /auth/refresh`, `POST /auth/logout`, `POST /auth/forgot-password`, `POST /auth/reset-password`.
 
-**Staff / Clientes / Mascotas** — `GET/POST/PATCH/DELETE /users`, `GET/POST/PUT/DELETE /clients`, `GET /pets`, `GET /pets/{id}` (perfil agregado), `POST /clients/{client_id}/pets`, `GET /search?q=`.
+**Staff / Clients / Pets** — `GET/POST/PATCH/DELETE /users`, `GET/POST/PUT/DELETE /clients`, `GET /pets`, `GET /pets/{id}` (aggregated profile), `POST /clients/{client_id}/pets`, `GET /search?q=`.
 
-**Agenda** — `GET /appointments?date=&view=day|week&vet_id=`, `POST /appointments` (409 por solapamiento), `PATCH /appointments/{id}` (reprogramar), `DELETE /appointments/{id}` (cancelar lógico), `PATCH /appointments/{id}/status` (marcar atendido), `GET /appointments/{id}/notifications`.
+**Agenda** — `GET /appointments?date=&view=day|week&vet_id=`, `POST /appointments` (409 on overlap), `PATCH /appointments/{id}` (reschedule), `DELETE /appointments/{id}` (logical cancel), `PATCH /appointments/{id}/status` (mark attended), `GET /appointments/{id}/notifications`.
 
-**Historia clínica** — `GET /pets/{id}/clinical-records` (paginado), `POST /clinical-records`, `GET /clinical-records/{id}`, `PATCH /clinical-records/{id}`, `DELETE /clinical-records/{id}`, `GET /clinical-records/by-appointment/{appointment_id}`, `POST/GET /clinical-records/{id}/attachments`, `DELETE /clinical-records/{id}/attachments/{attachment_id}`.
+**Clinical record** — `GET /pets/{id}/clinical-records` (paginated), `POST /clinical-records`, `GET /clinical-records/{id}`, `PATCH /clinical-records/{id}`, `DELETE /clinical-records/{id}`, `GET /clinical-records/by-appointment/{appointment_id}`, `POST/GET /clinical-records/{id}/attachments`, `DELETE /clinical-records/{id}/attachments/{attachment_id}`.
 
-**Vacunación** — `POST/GET /pets/{pet_id}/vaccinations`.
+**Vaccination** — `POST/GET /pets/{pet_id}/vaccinations`.
 
-**Asistente IA** (flujo diferenciador):
+**AI Assistant** (differentiating flow):
 
 ```yaml
 openapi: 3.1.0
@@ -526,37 +526,37 @@ info:
 paths:
   /ai/transcribe-voice:
     post:
-      summary: Encolar transcripción de una grabación de voz
+      summary: Enqueue transcription of a voice recording
       description: |
-        Recibe el audio grabado, valida formato/tamaño (≤ 20 MB) y encola una tarea ARQ
-        (Groq Whisper → Claude Haiku cleanup → Claude Sonnet tool use). Retorna un task_id
-        para polling. Rol vet/admin.
+        Receives the recorded audio, validates format/size (≤ 20 MB) and enqueues an ARQ task
+        (Groq Whisper → Claude Haiku cleanup → Claude Sonnet tool use). Returns a task_id
+        for polling. Role vet/admin.
       security: [{ bearerAuth: [] }]
       responses:
-        '202': { description: "Tarea encolada — { task_id, status: pending }" }
+        '202': { description: "Task enqueued — { task_id, status: pending }" }
         '413': { description: "Audio > 20 MB" }
-        '403': { description: "Rol distinto de vet o admin" }
+        '403': { description: "Role other than vet or admin" }
 
   /ai/transcribe-upload:
     post:
-      summary: Subir un archivo de audio externo para pre-llenado IA
+      summary: Upload an external audio file for AI pre-fill
       description: |
-        Igual al pipeline de transcribe-voice pero acepta un archivo subido
-        (MP3/MP4/WAV/M4A/WebM/AAC; valida MIME con fallback a extensión).
-        input_type="upload" en clinical_records_ai.
+        Same as the transcribe-voice pipeline but accepts an uploaded file
+        (MP3/MP4/WAV/M4A/WebM/AAC; validates MIME with fallback to extension).
+        input_type="upload" in clinical_records_ai.
       security: [{ bearerAuth: [] }]
       responses:
-        '202': { description: "Tarea encolada" }
-        '413': { description: "Archivo > 20 MB" }
-        '422': { description: "Formato no soportado / archivo vacío / pet_id inválido" }
+        '202': { description: "Task enqueued" }
+        '413': { description: "File > 20 MB" }
+        '422': { description: "Unsupported format / empty file / invalid pet_id" }
 
   /ai/tasks/{task_id}:
     get:
-      summary: Polling del resultado del pipeline IA
+      summary: Poll the AI pipeline result
       security: [{ bearerAuth: [] }]
       responses:
         '200':
-          description: Estado de la tarea
+          description: Task status
           content:
             application/json:
               schema:
@@ -571,23 +571,23 @@ paths:
                       weight_kg: { type: number, nullable: true }
                       temperature_c: { type: number, nullable: true }
                       referred_medication: { type: string, nullable: true }
-                      diagnosis: { type: string, nullable: true, description: "Solo si el vet lo dicta explícitamente; nunca inventado" }
-                      treatment: { type: string, nullable: true, description: "Solo si el vet lo dicta explícitamente; nunca inventado" }
+                      diagnosis: { type: string, nullable: true, description: "Only if the vet dictates it explicitly; never invented" }
+                      treatment: { type: string, nullable: true, description: "Only if the vet dictates it explicitly; never invented" }
                   model_used: { type: string }
                   error: { type: string, nullable: true }
 
   /clinical-records:
     post:
-      summary: Crear historia clínica
+      summary: Create clinical record
       description: |
-        Persiste la historia validada por el veterinario. Si trae appointment_id y el turno
-        está 'pending', lo transiciona a 'attended' (idempotente). El listener de SQLAlchemy
-        registra el insert en audit_log automáticamente. 409 si el turno ya tiene historia activa.
+        Persists the record validated by the veterinarian. If it carries an appointment_id and the
+        appointment is 'pending', it transitions it to 'attended' (idempotent). The SQLAlchemy listener
+        records the insert in audit_log automatically. 409 if the appointment already has an active record.
       security: [{ bearerAuth: [] }]
       responses:
-        '201': { description: Creada }
-        '409': { description: "El turno ya tiene una historia clínica activa" }
-        '403': { description: "Rol distinto de vet o admin" }
+        '201': { description: Created }
+        '409': { description: "The appointment already has an active clinical record" }
+        '403': { description: "Role other than vet or admin" }
 
 components:
   securitySchemes:
@@ -596,154 +596,154 @@ components:
 
 ---
 
-## 5. Historias de Usuario
+## 5. User Stories
 
-**Historia de Usuario 1 — Historia Clínica Asistida por IA (US-013, implementada)**
+**User Story 1 — AI-Assisted Clinical Record (US-013, implemented)**
 
-Como Veterinario, quiero grabar una nota de voz durante o después de la consulta y que la app **complete los campos predefinidos de la historia clínica** a partir de lo dictado, para reducir el tiempo de escritura administrativa.
+As a Veterinarian, I want to record a voice note during or after the consultation and have the app **fill in the predefined fields of the clinical record** from what is dictated, in order to reduce administrative writing time.
 
-**Criterios de aceptación (verificados):**
-- Inicio/detengo la grabación desde la app (MediaRecorder web); veo un indicador de procesamiento.
-- Recibo pre-completados: motivo, síntomas, peso, temperatura y medicación referida.
-- Diagnóstico y tratamiento se completan **solo si los dicté explícitamente**; la IA nunca los inventa (se distingue `referred_medication` —lo que el dueño ya dio— de `treatment` —lo que indica el vet—).
-- Puedo editar cualquier campo antes de guardar; si el procesamiento falla (timeout > 30s) completo el formulario manualmente.
-- El registro y la interacción IA quedan auditados en `clinical_records_ai`.
-
----
-
-**Historia de Usuario 2 — Agenda multi-veterinario sin solapamientos (US-017/018/019, implementada)**
-
-Como Recepcionista o Veterinario, quiero crear, reprogramar y cancelar turnos asignados a una mascota y un veterinario, para organizar la agenda sin solapamientos.
-
-**Criterios de aceptación (verificados):**
-- Selecciono mascota (búsqueda por nombre), veterinario, fecha y hora; el sistema detecta solapamiento (HTTP 409).
-- El turno aparece en la agenda Schedule-X (día/semana, filtrable por vet, en español, anclada al lunes).
-- Click en un turno pendiente abre reprogramar (re-valida disponibilidad) o cancelar (motivo opcional). La cancelación libera el horario (re-bookeable).
+**Acceptance criteria (verified):**
+- I start/stop the recording from the app (web MediaRecorder); I see a processing indicator.
+- I receive pre-filled: reason, symptoms, weight, temperature and referred medication.
+- Diagnosis and treatment are filled in **only if I dictated them explicitly**; the AI never invents them (it distinguishes `referred_medication` —what the owner already gave— from `treatment` —what the vet indicates—).
+- I can edit any field before saving; if processing fails (timeout > 30s) I complete the form manually.
+- The record and the AI interaction are audited in `clinical_records_ai`.
 
 ---
 
-**Historia de Usuario 3 — Adjuntar imágenes y archivos a una consulta (US-010, implementada)**
+**User Story 2 — Multi-veterinarian agenda without overlaps (US-017/018/019, implemented)**
 
-Como Veterinario, quiero adjuntar imágenes o PDFs a una consulta y verlos al reabrirla, para documentar estudios y evidencias.
+As a Receptionist or Veterinarian, I want to create, reschedule and cancel appointments assigned to a pet and a veterinarian, in order to organize the agenda without overlaps.
 
-**Criterios de aceptación (verificados):**
-- Adjunto archivos (JPEG/PNG/PDF, ≤ 20 MB, máx. 10); el lote se valida completo antes de subir nada (sin archivos huérfanos).
-- Los archivos se almacenan en Supabase Storage (bucket privado) y se sirven con URL firmada de corta vida.
-- Al reabrir la consulta veo la grilla de miniaturas; al hacer click se abre el archivo en una pestaña nueva. Borrado por adjunto (soft delete auditado).
-
----
-
-## 6. Tickets de Trabajo
-
-Tres tickets representativos del MVP implementado (backend, frontend y base de datos), con sus commits reales sobre `dev`.
+**Acceptance criteria (verified):**
+- I select a pet (search by name), veterinarian, date and time; the system detects overlap (HTTP 409).
+- The appointment appears in the Schedule-X agenda (day/week, filterable by vet, in Spanish, anchored to Monday).
+- Clicking a pending appointment opens reschedule (re-validates availability) or cancel (optional reason). Cancellation frees the slot (re-bookable).
 
 ---
 
-### Ticket 1 — Backend · `US-013-BE` (#323) · Talla: M · commit `5a4a45e`
+**User Story 3 — Attach images and files to a consultation (US-010, implemented)**
 
-**Título:** Endpoint de transcripción de voz con pipeline IA asíncrono
+As a Veterinarian, I want to attach images or PDFs to a consultation and see them when reopening it, in order to document studies and evidence.
 
-**Descripción técnica:** `POST /ai/transcribe-voice` recibe el audio, valida formato/tamaño y encola una tarea ARQ devolviendo `{ task_id, status: "pending" }` (202); el resultado se recupera con `GET /ai/tasks/{task_id}`. La tarea ARQ ejecuta, en secuencia: (1) transcripción con **Groq Whisper `whisper-large-v3`** (SDK de OpenAI con `base_url` override); (2) limpieza con **`claude-haiku-4-5`**; (3) extracción estructurada con **`claude-sonnet-4-6`** (tool use + schema Pydantic `ClinicalRecordExtraction`, `cache_control: ephemeral`); (4) auditoría: inserta una fila en `clinical_records_ai`. El worker crea su propia sesión con `set_config('app.clinic_id', …, true)` para respetar RLS sin contexto JWT.
+**Acceptance criteria (verified):**
+- I attach files (JPEG/PNG/PDF, ≤ 20 MB, max 10); the batch is fully validated before uploading anything (no orphan files).
+- Files are stored in Supabase Storage (private bucket) and served with a short-lived signed URL.
+- On reopening the consultation I see the thumbnail grid; clicking opens the file in a new tab. Per-attachment deletion (audited soft delete).
+
+---
+
+## 6. Work Tickets
+
+Three representative tickets of the implemented MVP (backend, frontend and database), with their real commits onto `dev`.
+
+---
+
+### Ticket 1 — Backend · `US-013-BE` (#323) · Size: M · commit `5a4a45e`
+
+**Title:** Voice transcription endpoint with asynchronous AI pipeline
+
+**Technical description:** `POST /ai/transcribe-voice` receives the audio, validates format/size and enqueues an ARQ task returning `{ task_id, status: "pending" }` (202); the result is retrieved with `GET /ai/tasks/{task_id}`. The ARQ task runs, in sequence: (1) transcription with **Groq Whisper `whisper-large-v3`** (OpenAI SDK with a `base_url` override); (2) cleanup with **`claude-haiku-4-5`**; (3) structured extraction with **`claude-sonnet-4-6`** (tool use + Pydantic `ClinicalRecordExtraction` schema, `cache_control: ephemeral`); (4) audit: inserts a row in `clinical_records_ai`. The worker creates its own session with `set_config('app.clinic_id', …, true)` to respect RLS without a JWT context.
 
 **Stack:** FastAPI · ARQ + Redis · Groq Whisper · Claude (haiku-4-5 + sonnet-4-6) · Pydantic v2 · pytest + syrupy.
 
-**Criterios de aceptación (BDD):**
-- *Happy path:* vet/admin envía audio válido → 202 + task_id; `GET /ai/tasks/{id}` → `status: "completed"` con los campos extraídos; fila en `clinical_records_ai`.
-- *Audio sin datos clínicos:* `completed` con campos `null`/vacíos; sin excepción; output vacío auditado.
-- *Timeout (> 30s):* `status: "failed"` con mensaje de fallback manual; sin reintento automático.
+**Acceptance criteria (BDD):**
+- *Happy path:* vet/admin sends valid audio → 202 + task_id; `GET /ai/tasks/{id}` → `status: "completed"` with the extracted fields; row in `clinical_records_ai`.
+- *Audio without clinical data:* `completed` with `null`/empty fields; no exception; empty output audited.
+- *Timeout (> 30s):* `status: "failed"` with a manual fallback message; no automatic retry.
 
-**Notas de implementación reales:** se requirió subir el SDK de `anthropic==0.34.2` a `0.111.0` y corregir los model IDs (`claude-haiku-4-5-20251001`, `claude-sonnet-4-6`); se pasó `api_key` explícito al cliente Anthropic porque el worker no heredaba el entorno. El prompt se ajustó para extraer diagnosis/treatment cuando el vet los dicta (sin forzarlos a `None`).
+**Real implementation notes:** it was necessary to bump the `anthropic` SDK from `0.34.2` to `0.111.0` and correct the model IDs (`claude-haiku-4-5-20251001`, `claude-sonnet-4-6`); an explicit `api_key` was passed to the Anthropic client because the worker did not inherit the environment. The prompt was adjusted to extract diagnosis/treatment when the vet dictates them (without forcing them to `None`).
 
-**INVEST:** I✅ N✅ V✅ E✅ S✅ T✅ · Dependencias: US-013-DB (#325), US-013-AI (#326).
-
----
-
-### Ticket 2 — Frontend · `US-013-FE` (#324) · Talla: M · commit `39d5ea9`
-
-**Título:** Grabación de voz con polling y pre-llenado de campos clínicos
-
-**Descripción técnica:** dentro de `frontend/src/features/ai-assistant/`: `VoiceRecorder.tsx` (MediaRecorder web-only con `Platform.OS` guard, estados grabar/detener/procesando, spinner, disclaimer y error con fallback); `useVoiceTranscription.ts` (hook con polling cada 2s, timeout 30s y mapeo de los 6 campos al formulario); integración en `ClinicalRecordFormModal.tsx` (solo modo create). Validación con Zod antes de `POST /clinical-records`.
-
-**Stack:** Expo Router · Tamagui (tokens Clinical Serenity) · TanStack Query · Zustand · Zod · MediaRecorder.
-
-**Criterios de aceptación (BDD):**
-- *Happy path:* grabar → detener → `completed` < 30s → se pre-llenan motivo/síntomas/peso/temperatura/medicación (y diagnóstico/tratamiento si fueron dictados); disclaimer visible; todo editable.
-- *Extracción parcial:* los campos no extraídos quedan con placeholder vacío (no "null"), completables sin marcar error.
-- *Timeout/error:* mensaje de fallback y formulario habilitado para entrada manual; botón de grabación disponible para reintentar.
-
-**Notas reales:** durante el testing se corrigieron warnings de props de accesibilidad filtradas al DOM (`accessibilityRole`/`accessibilityState` solo-native) y la invalidación de queries al guardar (`useCreateClinicalRecord` ahora invalida también `["appointments"]` y la consulta por turno).
-
-**INVEST:** I✅ N✅ V✅ E✅ S✅ T✅ · Dependencias: US-013-BE.
+**INVEST:** I✅ N✅ V✅ E✅ S✅ T✅ · Dependencies: US-013-DB (#325), US-013-AI (#326).
 
 ---
 
-### Ticket 3 — Base de datos · `US-009-DB` (dentro de #315) · Talla: M · commit `9b9ed5f`
+### Ticket 2 — Frontend · `US-013-FE` (#324) · Size: M · commit `39d5ea9`
 
-**Título:** Tabla `audit_log` append-only con REVOKE y listener SQLAlchemy automático
+**Title:** Voice recording with polling and clinical field pre-fill
 
-**Descripción técnica:** migración `0005_clinical_records_and_audit_log.py` que crea `clinical_records` y `audit_log` (índices + RLS forzada + grants, incluyendo `REVOKE UPDATE, DELETE ON audit_log FROM app_runtime`) y registra el listener genérico `setup_audit_listener` (`after_flush`, anti-recursión, snapshot en `create` / diff en `update`). El listener es transparente: ningún endpoint lo llama explícitamente. Acciones específicas (`status_change`, `attachment_added`) se anotan suprimiendo la fila genérica vía `session.info["audit_skip"]`.
+**Technical description:** inside `frontend/src/features/ai-assistant/`: `VoiceRecorder.tsx` (web-only MediaRecorder with a `Platform.OS` guard, record/stop/processing states, spinner, disclaimer and error with fallback); `useVoiceTranscription.ts` (hook with polling every 2s, 30s timeout and mapping of the 6 fields to the form); integration in `ClinicalRecordFormModal.tsx` (create mode only). Validation with Zod before `POST /clinical-records`.
+
+**Stack:** Expo Router · Tamagui (Clinical Serenity tokens) · TanStack Query · Zustand · Zod · MediaRecorder.
+
+**Acceptance criteria (BDD):**
+- *Happy path:* record → stop → `completed` < 30s → reason/symptoms/weight/temperature/medication are pre-filled (and diagnosis/treatment if they were dictated); disclaimer visible; everything editable.
+- *Partial extraction:* the non-extracted fields stay with an empty placeholder (not "null"), completable without marking an error.
+- *Timeout/error:* fallback message and the form enabled for manual entry; record button available to retry.
+
+**Real notes:** during testing, accessibility prop warnings leaked to the DOM were fixed (`accessibilityRole`/`accessibilityState` native-only) and query invalidation on save (`useCreateClinicalRecord` now also invalidates `["appointments"]` and the by-appointment query).
+
+**INVEST:** I✅ N✅ V✅ E✅ S✅ T✅ · Dependencies: US-013-BE.
+
+---
+
+### Ticket 3 — Database · `US-009-DB` (within #315) · Size: M · commit `9b9ed5f`
+
+**Title:** Append-only `audit_log` table with REVOKE and an automatic SQLAlchemy listener
+
+**Technical description:** migration `0005_clinical_records_and_audit_log.py` that creates `clinical_records` and `audit_log` (indexes + forced RLS + grants, including `REVOKE UPDATE, DELETE ON audit_log FROM app_runtime`) and registers the generic listener `setup_audit_listener` (`after_flush`, anti-recursion, snapshot on `create` / diff on `update`). The listener is transparent: no endpoint calls it explicitly. Specific actions (`status_change`, `attachment_added`) are annotated by suppressing the generic row via `session.info["audit_skip"]`.
 
 **Stack:** PostgreSQL 16 · Alembic · SQLAlchemy 2.0 async · pytest.
 
-**Criterios de aceptación (BDD):**
-- *Mutación auditada:* al hacer flush de un update sobre `clinical_records`, se inserta una fila en `audit_log` con `table_name`, `record_id`, `action`, `changed_by_user_id` y diff JSONB; sin llamada explícita.
-- *Append-only garantizado:* `UPDATE`/`DELETE` sobre `audit_log` desde `app_runtime` → `permission denied`; test bloqueante.
-- *Rendimiento:* las queries de auditoría usan índice compuesto.
+**Acceptance criteria (BDD):**
+- *Audited mutation:* when flushing an update on `clinical_records`, a row is inserted in `audit_log` with `table_name`, `record_id`, `action`, `changed_by_user_id` and JSONB diff; without an explicit call.
+- *Append-only guaranteed:* `UPDATE`/`DELETE` on `audit_log` from `app_runtime` → `permission denied`; blocking test.
+- *Performance:* the audit queries use a composite index.
 
-**Notas reales:** durante el QA se detectó que `audit_log.actor_ip` estaba tipado `String(45)` en el modelo pero la migración lo crea como `INET` en Postgres → toda escritura tenant-scoped daba 500 (no detectado por SQLite); fix: `INET().with_variant(String(45), "sqlite")` (commit `3e9ddd1`).
+**Real notes:** during QA it was found that `audit_log.actor_ip` was typed `String(45)` in the model but the migration creates it as `INET` in Postgres → every tenant-scoped write returned 500 (not caught by SQLite); fix: `INET().with_variant(String(45), "sqlite")` (commit `3e9ddd1`).
 
-**INVEST:** I✅ N✅ V✅ E✅ S✅ T✅ · Dependencias: roles `app_runtime`/`app_admin` (US-001-DB).
+**INVEST:** I✅ N✅ V✅ E✅ S✅ T✅ · Dependencies: `app_runtime`/`app_admin` roles (US-001-DB).
 
 ---
 
 ## 7. Pull Requests
 
-El desarrollo del MVP se hizo con un PR por User Story sobre la rama `dev` (24 PRs, `feat/us-XXX → dev`, un commit por ticket). A continuación, tres PRs representativos del flujo diferenciador; la lista completa está debajo.
+MVP development was done with one PR per User Story onto the `dev` branch (24 PRs, `feat/us-XXX → dev`, one commit per ticket). Below, three representative PRs of the differentiating flow; the full list is below.
 
-**Pull Request 1 — US-013 Asistente IA: voz → campos clínicos (PR #415)**
+**Pull Request 1 — US-013 AI Assistant: voice → clinical fields (PR #415)**
 
-- **Branch:** `feat/us-013` → `dev` *(mergeado, commit `60fdf33`)*
-- **Contenido:** pipeline IA completo end-to-end. DB (`0011_clinical_records_ai` append-only), AI (schema `ClinicalRecordExtraction` + system prompt + snapshots syrupy), BE (`POST /ai/transcribe-voice`, `GET /ai/tasks/{id}`, tarea ARQ Groq Whisper → Haiku → Sonnet), FE (`VoiceRecorder` + `useVoiceTranscription` + integración al modal). Incluye el ajuste del prompt para extraer diagnóstico/tratamiento cuando el vet los dicta.
+- **Branch:** `feat/us-013` → `dev` *(merged, commit `60fdf33`)*
+- **Content:** complete end-to-end AI pipeline. DB (`0011_clinical_records_ai` append-only), AI (`ClinicalRecordExtraction` schema + system prompt + syrupy snapshots), BE (`POST /ai/transcribe-voice`, `GET /ai/tasks/{id}`, ARQ task Groq Whisper → Haiku → Sonnet), FE (`VoiceRecorder` + `useVoiceTranscription` + integration into the modal). Includes the prompt adjustment to extract diagnosis/treatment when the vet dictates them.
 
-**Pull Request 2 — US-018 Agenda diaria/semanal (PR #396)**
+**Pull Request 2 — US-018 Daily/weekly agenda (PR #396)**
 
-- **Branch:** `feat/us-018` → `dev` *(mergeado, commit `752a28a`)*
-- **Contenido:** `GET /appointments?date=&view=&vet_id=` (sin N+1) + pantalla `(app)/agenda.tsx` con Schedule-X v2 (español, navegación por semana anclada al lunes, filtro por vet, botón "Nuevo turno"). Integra la búsqueda global como selector de mascota. Incluye `frontend/.npmrc` (`legacy-peer-deps=true`) para resolver el ERESOLVE de `@schedule-x/react` en CI.
+- **Branch:** `feat/us-018` → `dev` *(merged, commit `752a28a`)*
+- **Content:** `GET /appointments?date=&view=&vet_id=` (without N+1) + screen `(app)/agenda.tsx` with Schedule-X v2 (Spanish, weekly navigation anchored to Monday, filter by vet, "New appointment" button). Integrates the global search as a pet selector. Includes `frontend/.npmrc` (`legacy-peer-deps=true`) to resolve the `@schedule-x/react` ERESOLVE in CI.
 
-**Pull Request 3 — US-010 Adjuntos clínicos (PR #414)**
+**Pull Request 3 — US-010 Clinical attachments (PR #414)**
 
-- **Branch:** `feat/us-010` → `dev` *(mergeado, commit `85301a6`)*
-- **Contenido:** `clinical_attachments` (tenant-scoped + RLS), `StorageService` real (Strategy supabase/s3, DI mockeable), `POST/GET /clinical-records/{id}/attachments` (valida el lote antes de subir, signed URL por respuesta), FE con `AttachmentPicker` + grilla de miniaturas + apertura en pestaña nueva. Fix del listener de auditoría para honrar `audit_skip` también en la rama de creates. PR #418 (`fix/clinical-attachments-ux`) pulió la UX (borrar sin abrir, refrescar historial al crear, auto-cerrar).
+- **Branch:** `feat/us-010` → `dev` *(merged, commit `85301a6`)*
+- **Content:** `clinical_attachments` (tenant-scoped + RLS), real `StorageService` (Strategy supabase/s3, mockable DI), `POST/GET /clinical-records/{id}/attachments` (validates the batch before uploading, signed URL per response), FE with `AttachmentPicker` + thumbnail grid + opening in a new tab. Fix of the audit listener to honor `audit_skip` also in the create branch. PR #418 (`fix/clinical-attachments-ux`) polished the UX (delete without opening, refresh history on create, auto-close).
 
 ---
 
-**Listado completo de PRs mergeados a `dev`:**
+**Complete list of PRs merged to `dev`:**
 
 | PR | US | Feature |
 |---|---|---|
-| #388 | US-001 | Registro de clínica (INFRA + DB + RLS + BE + FE) |
-| #389 | US-002 | Login con JWT + redirección por rol |
-| #390 | US-003 | Gestión de usuarios staff (RBAC) |
-| #391 | US-005 | Registrar cliente |
-| #392 | US-004 | Recuperación de contraseña (migración Resend → SMTP `aiosmtplib`) |
-| #393 | US-006 | Registrar mascota |
-| #394 | US-017 | Crear turno (detección de solapamiento) |
-| #395 | US-007 | Búsqueda global enriquecida |
-| #396 | US-018 | Agenda diaria/semanal (Schedule-X) |
-| #397 | US-009 | Registrar consulta + `audit_log` automático |
-| #398 | US-023 | Registrar vacuna aplicada |
-| #399 | US-019 | Reprogramar / cancelar turno |
-| #400 | US-008 | Perfil clínico completo de la mascota |
-| #401 | US-011 | Historial clínico paginado + `clinical_record_access_log` |
-| #405 | US-020 | Marcar turno atendido e iniciar consulta |
-| #406 | US-020b | Ver/editar la consulta de un turno (sin duplicar, 409) |
-| #407 | US-021 | Recordatorio diario por email (cron + SMTP) |
-| #408 | US-022 | Estado efectivo de notificación del turno |
-| #413 | US-DASH | Dashboard por rol + listados de clientes/mascotas |
-| #414 | US-010 | Adjuntos clínicos (Supabase Storage) |
-| #415 | US-013 | Asistente IA: voz → campos clínicos |
-| #416 | US-014 | Subida de audio externo para pre-llenado IA |
-| #417 | US-012 | Editar/eliminar consulta propia |
-| #418 | — | Fix UX de adjuntos de historia clínica |
+| #388 | US-001 | Clinic registration (INFRA + DB + RLS + BE + FE) |
+| #389 | US-002 | Login with JWT + role-based redirection |
+| #390 | US-003 | Staff user management (RBAC) |
+| #391 | US-005 | Register client |
+| #392 | US-004 | Password recovery (Resend → SMTP `aiosmtplib` migration) |
+| #393 | US-006 | Register pet |
+| #394 | US-017 | Create appointment (overlap detection) |
+| #395 | US-007 | Enriched global search |
+| #396 | US-018 | Daily/weekly agenda (Schedule-X) |
+| #397 | US-009 | Register consultation + automatic `audit_log` |
+| #398 | US-023 | Register applied vaccine |
+| #399 | US-019 | Reschedule / cancel appointment |
+| #400 | US-008 | Complete clinical profile of the pet |
+| #401 | US-011 | Paginated clinical history + `clinical_record_access_log` |
+| #405 | US-020 | Mark appointment attended and start consultation |
+| #406 | US-020b | View/edit an appointment's consultation (without duplicating, 409) |
+| #407 | US-021 | Daily email reminder (cron + SMTP) |
+| #408 | US-022 | Effective appointment notification status |
+| #413 | US-DASH | Role-based dashboard + client/pet listings |
+| #414 | US-010 | Clinical attachments (Supabase Storage) |
+| #415 | US-013 | AI Assistant: voice → clinical fields |
+| #416 | US-014 | External audio upload for AI pre-fill |
+| #417 | US-012 | Edit/delete own consultation |
+| #418 | — | Clinical record attachments UX fix |
 
-> El paso a Done del board es manual: como los PRs apuntan a `dev` (no a `main`, la rama default), el `Closes #N` solo auto-cierra al integrar `dev → main`.
+> Moving the board to Done is manual: since the PRs target `dev` (not `main`, the default branch), the `Closes #N` only auto-closes when integrating `dev → main`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the Spanish README with a complete project overview, architecture diagrams, multi-tenancy/security model, data model details, and API behavior (including async AI processing).
  * Added end-to-end installation, testing, and usage guidance with local run commands and environment setup.
  * Rewrote the prompts documentation into a session-based development narrative, covering the end-to-end implementation flow, selected prompt reasoning, and key recorded decisions/deviations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->